### PR TITLE
deps: Upgrade the dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,9 +9,7 @@ pytest-cov = "*"
 pytest-flake8 = "*"
 pytest-mypy = ">=0.3.3"
 sphinx = "*"
-# Waiting for 0.2, master got lots of fixes and improvements since the last
-# release: https://github.com/dropbox/sqlalchemy-stubs/issues/78
-sqlalchemy-stubs = {git = "https://github.com/dropbox/sqlalchemy-stubs.git"}
+sqlalchemy-stubs = ">=0.2"
 
 [packages]
 psycopg2 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4167f9d20a0db9ce73d4aaff16d5f25c4c3a7690acf7ebc84c9b3a1087f7e04a"
+            "sha256": "2a33c3b7a78c75acb06bb165f0291827f28f728dca08d6ae24dc6950add37698"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -249,13 +249,12 @@
                 "sha256:3ad685ff8512bf6dc5a8b82ebf73543999b657eded8c11803d9ba6b648986f4d",
                 "sha256:8bb43d1f51ecef60d81854af61a3a880555a14643691cc4b64a6ee269c78f09a"
             ],
-            "markers": "python_version > '2.7'",
             "version": "==7.1.0"
         },
         "mypy": {
             "editable": true,
             "git": "https://github.com/HashBangCoop/mypy.git",
-            "ref": "e1192ee4fe2caec6a8e65ce1878918610898fed4"
+            "ref": "64d0bc2e0a06d3049c7437b85a0671d2fd810f53"
         },
         "mypy-extensions": {
             "hashes": [
@@ -315,11 +314,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45",
-                "sha256:926855726d8ae8371803f7b2e6ec0a69953d9c6311fa7c3b6c1b929ff92d27da"
+                "sha256:2878de8ae1c79a62c012da6186b88ff0562ea96ce29c4208d2a9b11d9f607df1",
+                "sha256:95b700cf21ed5b7e91bce7a6b5a573b2e3ef7b3643d00f681d8f9c4672f9fbdf"
             ],
             "index": "pypi",
-            "version": "==4.6.3"
+            "version": "==5.0.0"
         },
         "pytest-cov": {
             "hashes": [
@@ -423,8 +422,12 @@
             "version": "==1.1.3"
         },
         "sqlalchemy-stubs": {
-            "git": "https://github.com/dropbox/sqlalchemy-stubs.git",
-            "ref": "420f5685c0c9860147c8b62bec566bdc2c4b4dd7"
+            "hashes": [
+                "sha256:4bb4a0377ed6c01bea2e1124d60747714d56742352bdb80e2093ca80a1bc036f",
+                "sha256:fe9df983274142f82973e4f7634a98dcbdbdde964918ad3dcf33d94398c51537"
+            ],
+            "index": "pypi",
+            "version": "==0.2"
         },
         "typed-ast": {
             "hashes": [


### PR DESCRIPTION
Now that this was released, we don't need to rely on a Git snapshot for
sqlalchemy-stubs any more.