### PR TITLE
Some model changes to the activation/ping processors

### DIFF
--- a/azafea/event_processors/activation/v1.py
+++ b/azafea/event_processors/activation/v1.py
@@ -53,7 +53,6 @@ class Activation(Base):
     longitude = Column(Numeric)
 
     created_at = Column(DateTime(timezone=True), nullable=False, index=True)
-    updated_at = Column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (
         CheckConstraint('char_length(country) = 3', name='country_code_3_chars'),

--- a/azafea/event_processors/activation/v1.py
+++ b/azafea/event_processors/activation/v1.py
@@ -52,7 +52,7 @@ class Activation(Base):
     latitude = Column(Numeric)
     longitude = Column(Numeric)
 
-    created_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, index=True)
     updated_at = Column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (

--- a/azafea/event_processors/ping/v1.py
+++ b/azafea/event_processors/ping/v1.py
@@ -43,7 +43,7 @@ class PingConfiguration(Base):
     product = Column(Unicode, nullable=False)
     dualboot = Column(NullableBoolean, nullable=False, server_default='unknown')
 
-    created_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, index=True)
     updated_at = Column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (
@@ -79,14 +79,14 @@ class Ping(Base):
     __tablename__ = 'ping_v1'
 
     id = Column(Integer, primary_key=True)
-    config_id = Column(Integer, ForeignKey('ping_configuration_v1.id'), nullable=False)
+    config_id = Column(Integer, ForeignKey('ping_configuration_v1.id'), nullable=False, index=True)
     release = Column(Unicode, nullable=False)
     count = Column(Integer, nullable=False)
     country = Column(Unicode(length=3))
     metrics_enabled = Column(Boolean)
     metrics_environment = Column(Unicode)
 
-    created_at = Column(DateTime(timezone=True), index=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, index=True)
     updated_at = Column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (

--- a/azafea/tests/integration/activation/test_activation_v1.py
+++ b/azafea/tests/integration/activation/test_activation_v1.py
@@ -36,14 +36,12 @@ class TestActivation(IntegrationTest):
 
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
-        updated_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.redis.lpush('test_activation_v1', json.dumps({
             'image': 'image',
             'vendor': 'vendor',
             'product': 'product',
             'release': 'release',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
-            'updated_at': updated_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         }))
 
         # Run Azafea so it processes the event
@@ -57,7 +55,6 @@ class TestActivation(IntegrationTest):
             assert activation.product == 'product'
             assert activation.release == 'release'
             assert activation.created_at == created_at
-            assert activation.updated_at == updated_at
 
     def test_activation_v1_valid_country(self):
         from azafea.event_processors.activation.v1 import Activation
@@ -68,7 +65,6 @@ class TestActivation(IntegrationTest):
 
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
-        updated_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.redis.lpush('test_activation_v1_valid_country', json.dumps({
             'image': 'image',
             'vendor': 'vendor',
@@ -76,7 +72,6 @@ class TestActivation(IntegrationTest):
             'release': 'release',
             'country': 'FRA',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
-            'updated_at': updated_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         }))
 
         # Run Azafea so it processes the event
@@ -91,7 +86,6 @@ class TestActivation(IntegrationTest):
             assert activation.release == 'release'
             assert activation.country == 'FRA'
             assert activation.created_at == created_at
-            assert activation.updated_at == updated_at
 
     def test_activation_v1_empty_country(self):
         from azafea.event_processors.activation.v1 import Activation
@@ -102,7 +96,6 @@ class TestActivation(IntegrationTest):
 
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
-        updated_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.redis.lpush('test_activation_v1_empty_country', json.dumps({
             'image': 'image',
             'vendor': 'vendor',
@@ -110,7 +103,6 @@ class TestActivation(IntegrationTest):
             'release': 'release',
             'country': '',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
-            'updated_at': updated_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         }))
 
         # Run Azafea so it processes the event
@@ -125,7 +117,6 @@ class TestActivation(IntegrationTest):
             assert activation.release == 'release'
             assert activation.country is None
             assert activation.created_at == created_at
-            assert activation.updated_at == updated_at
 
     def test_activation_v1_invalid_country(self):
         from azafea.event_processors.activation.v1 import Activation
@@ -136,7 +127,6 @@ class TestActivation(IntegrationTest):
 
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
-        updated_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         record = json.dumps({
             'image': 'image',
             'vendor': 'vendor',
@@ -144,7 +134,6 @@ class TestActivation(IntegrationTest):
             'release': 'release',
             'country': 'FR',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
-            'updated_at': updated_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         })
         self.redis.lpush('test_activation_v1_invalid_country', record)
 

--- a/azafea/tests/integration/ping/test_ping_v1.py
+++ b/azafea/tests/integration/ping/test_ping_v1.py
@@ -36,7 +36,6 @@ class TestPing(IntegrationTest):
 
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
-        updated_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.redis.lpush('test_ping_v1', json.dumps({
             'image': 'image',
             'vendor': 'vendor',
@@ -45,7 +44,6 @@ class TestPing(IntegrationTest):
             'release': 'release',
             'count': 0,
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
-            'updated_at': updated_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         }))
 
         # Run Azafea so it processes the event
@@ -59,13 +57,11 @@ class TestPing(IntegrationTest):
             assert config.product == 'product'
             assert config.dualboot is True
             assert config.created_at == created_at
-            assert config.updated_at == updated_at
 
             ping = dbsession.query(Ping).one()
             assert ping.release == 'release'
             assert ping.count == 0
             assert ping.created_at == created_at
-            assert ping.updated_at == updated_at
 
     def test_ping_v1_valid_country(self):
         from azafea.event_processors.ping.v1 import PingConfiguration, Ping
@@ -76,7 +72,6 @@ class TestPing(IntegrationTest):
 
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
-        updated_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.redis.lpush('test_ping_v1_valid_country', json.dumps({
             'image': 'image',
             'vendor': 'vendor',
@@ -86,7 +81,6 @@ class TestPing(IntegrationTest):
             'count': 0,
             'country': 'FRA',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
-            'updated_at': updated_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         }))
 
         # Run Azafea so it processes the event
@@ -100,14 +94,12 @@ class TestPing(IntegrationTest):
             assert config.product == 'product'
             assert config.dualboot is True
             assert config.created_at == created_at
-            assert config.updated_at == updated_at
 
             ping = dbsession.query(Ping).one()
             assert ping.release == 'release'
             assert ping.count == 0
             assert ping.country == 'FRA'
             assert ping.created_at == created_at
-            assert ping.updated_at == updated_at
 
     def test_ping_v1_empty_country(self):
         from azafea.event_processors.ping.v1 import PingConfiguration, Ping
@@ -118,7 +110,6 @@ class TestPing(IntegrationTest):
 
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
-        updated_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.redis.lpush('test_ping_v1_empty_country', json.dumps({
             'image': 'image',
             'vendor': 'vendor',
@@ -128,7 +119,6 @@ class TestPing(IntegrationTest):
             'count': 0,
             'country': '',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
-            'updated_at': updated_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         }))
 
         # Run Azafea so it processes the event
@@ -142,14 +132,12 @@ class TestPing(IntegrationTest):
             assert config.product == 'product'
             assert config.dualboot is True
             assert config.created_at == created_at
-            assert config.updated_at == updated_at
 
             ping = dbsession.query(Ping).one()
             assert ping.release == 'release'
             assert ping.count == 0
             assert ping.country is None
             assert ping.created_at == created_at
-            assert ping.updated_at == updated_at
 
     def test_ping_v1_invalid_country(self):
         from azafea.event_processors.ping.v1 import PingConfiguration, Ping
@@ -160,7 +148,6 @@ class TestPing(IntegrationTest):
 
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
-        updated_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         record = json.dumps({
             'image': 'image',
             'vendor': 'vendor',
@@ -170,7 +157,6 @@ class TestPing(IntegrationTest):
             'count': 0,
             'country': 'FR',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
-            'updated_at': updated_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         })
         self.redis.lpush('test_ping_v1_invalid_country', record)
 
@@ -195,7 +181,6 @@ class TestPing(IntegrationTest):
 
         # Send events to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
-        updated_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         for i in range(10):
             self.redis.lpush('test_ping_configuration_v1_dualboot_unicity', json.dumps({
                 'image': 'image',
@@ -205,7 +190,6 @@ class TestPing(IntegrationTest):
                 'release': 'release',
                 'count': 0,
                 'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
-                'updated_at': updated_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
             }))
 
         # Run Azafea so it processes the events
@@ -224,7 +208,6 @@ class TestPing(IntegrationTest):
                 assert config.product == 'product'
                 assert config.dualboot == (True, False, None)[i % 3]
                 assert config.created_at == created_at
-                assert config.updated_at == updated_at
 
             pings = dbsession.query(Ping)
             assert pings.count() == 10


### PR DESCRIPTION
While making some of the requested queries to the DB, I found some interesting indexes to have, which are added here.

The `updated_at` columns was deemed unnecessary and is now removed.

Finally, this makes ping inserts faster by removing one query entirely.