### PR TITLE
ping: Handle missing counts

### DIFF
--- a/azafea/event_processors/ping/v1.py
+++ b/azafea/event_processors/ping/v1.py
@@ -111,6 +111,9 @@ class Ping(Base):
     def from_serialized(cls, serialized: bytes) -> 'Ping':
         record = json.loads(serialized.decode('utf-8'))
 
+        # Older images had a bug where count=0 would not be sent
+        record.setdefault('count', 0)
+
         return cls(**record)
 
 


### PR DESCRIPTION
Older images had a bug where they wouldn't send a count when it was 0:

https://github.com/endlessm/eos-phone-home/commit/7145393a1038e9dccfa990836b53dbd11e48835a

We continue receiving pings from such old images, and as such we need to
be able to handle them gracefully.

cc @ramcq 