### PR TITLE
model: Fix queries on nulleable booleans

### DIFF
--- a/azafea/model.py
+++ b/azafea/model.py
@@ -156,6 +156,8 @@ class NullableBoolean(TypeDecorator):
 
         super().__init__('true', 'false', 'unknown', **kwargs)
 
+    coerce_to_is_types = ()
+
     def process_bind_param(self, value: Optional[bool], dialect: Any) -> str:
         """Convert the Python values into the SQL ones"""
         return {

--- a/azafea/tests/integration/nullableboolean/test_nullableboolean.py
+++ b/azafea/tests/integration/nullableboolean/test_nullableboolean.py
@@ -47,3 +47,19 @@ class TestNullableBoolean(IntegrationTest):
             result = dbsession.execute(text('SELECT value FROM nullableboolean_event'))
             assert result.rowcount == 1
             assert result.fetchone()[0] == name
+
+    def test_query_filtered_on_none(self):
+        from .handler_module import Event
+
+        # Create the table
+        assert self.run_subcommand('initdb') == cli.ExitCode.OK
+        self.ensure_tables(Event)
+
+        # Insert a value
+        with self.db as dbsession:
+            dbsession.add(Event(name='hello', value=None))
+
+        # Try filtering on the None value
+        with self.db as dbsession:
+            event = dbsession.query(Event).filter_by(value=None).one()
+            assert event.name == 'hello'


### PR DESCRIPTION
The NullableBoolean type allows inserting records with a column which
can be either True, False or None, while properly handling unicity
constraints.

To do that is uses a string enum with three states ('true', 'false' and
'unknown') to the Python values (True, False and None).

However, when trying to filter queries on such a column being None in
Python, SQLAlchemy would generate an SQL with "column IS NULL", instead
or the expected "column = 'unknown'.

This commit fixes that.

Fortunately, we had never done such queries in Python yet, so this bug
didn't actually cause any trouble.