### PR TITLE
metrics: Do not normalize the display vendors

### DIFF
--- a/azafea/event_processors/metrics/events/__init__.py
+++ b/azafea/event_processors/metrics/events/__init__.py
@@ -335,7 +335,7 @@ class MonitorConnected(SingularEvent):
     def _get_fields_from_payload(payload: GLib.Variant) -> Dict[str, Any]:
         return {
             'display_name': payload.get_child_value(0).get_string(),
-            'display_vendor': normalize_vendor(payload.get_child_value(1).get_string()),
+            'display_vendor': payload.get_child_value(1).get_string(),
             'display_product': payload.get_child_value(2).get_string(),
             'display_width': payload.get_child_value(4).get_int32(),
             'display_height': payload.get_child_value(5).get_int32(),
@@ -361,7 +361,7 @@ class MonitorDisconnected(SingularEvent):
     def _get_fields_from_payload(payload: GLib.Variant) -> Dict[str, Any]:
         return {
             'display_name': payload.get_child_value(0).get_string(),
-            'display_vendor': normalize_vendor(payload.get_child_value(1).get_string()),
+            'display_vendor': payload.get_child_value(1).get_string(),
             'display_product': payload.get_child_value(2).get_string(),
             'display_width': payload.get_child_value(4).get_int32(),
             'display_height': payload.get_child_value(5).get_int32(),

--- a/azafea/event_processors/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/metrics/tests/integration/test_metrics_v2.py
@@ -352,7 +352,7 @@ class TestMetrics(IntegrationTest):
                         15000000000,                   # event relative timestamp (15 secs)
                         GLib.Variant('(ssssiiay)', (
                             'Samsung Electric Company 22',
-                            'Samsung Electronics Co.,Ltd',
+                            'SAM',
                             'S22E450',
                             'serial number ignored',
                             500,
@@ -366,7 +366,7 @@ class TestMetrics(IntegrationTest):
                         14000000000,                   # event relative timestamp (14 secs)
                         GLib.Variant('(ssssiiay)', (
                             'Samsung Electric Company 22',
-                            'Samsung Electronics Co.,Ltd',
+                            'SAM',
                             'S22E450',
                             'serial number ignored',
                             500,
@@ -645,7 +645,7 @@ class TestMetrics(IntegrationTest):
             assert monitor.user_id == user_id
             assert monitor.occured_at == now - timedelta(seconds=2) + timedelta(seconds=15)
             assert monitor.display_name == 'Samsung Electric Company 22'
-            assert monitor.display_vendor == 'Samsung'
+            assert monitor.display_vendor == 'SAM'
             assert monitor.display_product == 'S22E450'
             assert monitor.display_width == 500
             assert monitor.display_height == 350
@@ -656,7 +656,7 @@ class TestMetrics(IntegrationTest):
             assert monitor.user_id == user_id
             assert monitor.occured_at == now - timedelta(seconds=2) + timedelta(seconds=14)
             assert monitor.display_name == 'Samsung Electric Company 22'
-            assert monitor.display_vendor == 'Samsung'
+            assert monitor.display_vendor == 'SAM'
             assert monitor.display_product == 'S22E450'
             assert monitor.display_width == 500
             assert monitor.display_height == 350


### PR DESCRIPTION
Turns out those are always a code made of 3 upper-case letters, rather
than the full name of the vendor.

https://en.wikipedia.org/wiki/Extended_Display_Identification_Data#Structure,_version_1.4

If we really want to normalize these, it will have to be with its own
mapping.

Fortunately this hasn't been deployed yet.