### PR TITLE
Some change for the metrics import

### DIFF
--- a/azafea/event_processors/metrics/request.py
+++ b/azafea/event_processors/metrics/request.py
@@ -25,7 +25,7 @@ class Request(Base):
     __tablename__ = 'metrics_request_v2'
 
     id = Column(Integer, primary_key=True)
-    serialized = Column(LargeBinary, nullable=False)
+    serialized = Column(LargeBinary)
     sha512 = Column(Unicode, nullable=False, unique=True)
     received_at = Column(DateTime(timezone=True), nullable=False)
     absolute_timestamp = Column(BigInteger, nullable=False)

--- a/azafea/event_processors/metrics/tests/integration/test_metrics_v2_import.py
+++ b/azafea/event_processors/metrics/tests/integration/test_metrics_v2_import.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2019 - Endless
+#
+# This file is part of Azafea
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+from datetime import datetime, timedelta, timezone
+from hashlib import sha512
+from uuid import UUID
+
+from gi.repository import GLib
+
+from azafea.tests.integration import IntegrationTest
+
+
+class TestMetrics(IntegrationTest):
+    handler_module = 'azafea.event_processors.metrics.v2_import'
+
+    def test_request(self):
+        from azafea.event_processors.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request)
+
+        # Build a request as it would have been sent to us
+        now = datetime.now(tz=timezone.utc)
+        machine_id = 'ffffffffffffffffffffffffffffffff'
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id),
+                [],                                    # singular events
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_request', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).one()
+
+            assert request.send_number == 0
+            assert request.machine_id == machine_id
+            assert request.sha512 == sha512(request_body).hexdigest()
+            assert request.received_at == received_at
+            assert request.serialized is None
+
+    def test_duplicate_request(self):
+        from azafea.event_processors.metrics.events._base import UnknownSingularEvent
+        from azafea.event_processors.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request)
+
+        # Build a request as it would have been sent to us
+        now = datetime.now(tz=timezone.utc)
+        machine_id = 'ffffffffffffffffffffffffffffffff'
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id),
+                [                                      # singular events
+                    (
+                        1000,                          # user id
+                        UUID('d3863909-8eff-43b6-9a33-ef7eda266195').bytes,
+                        3000000000,                    # event relative timestamp (3 secs)
+                        None,                          # empty payload
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue, twice
+        self.redis.lpush('test_duplicate_request', record)
+        self.redis.lpush('test_duplicate_request', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).one()
+
+            assert request.send_number == 0
+            assert request.machine_id == machine_id
+            assert request.sha512 == sha512(request_body).hexdigest()
+            assert request.received_at == received_at
+            assert request.serialized is None
+
+            # Ensure we deduplicated the request and the events it contains
+            assert dbsession.query(UnknownSingularEvent).count() == 1

--- a/azafea/event_processors/metrics/v2.py
+++ b/azafea/event_processors/metrics/v2.py
@@ -19,11 +19,14 @@ from .request import RequestBuilder
 log = logging.getLogger(__name__)
 
 
-def process(dbsession: DbSession, record: bytes) -> None:
-    log.debug('Processing metric v2 record: %s', record)
-
+def do_process(dbsession: DbSession, record: bytes, discard_serialized: bool = False) -> None:
     request_builder = RequestBuilder.parse_bytes(record)
     request = request_builder.build_request()
+
+    # FIXME: Remove this once the import is successful
+    if discard_serialized:
+        request.serialized = None
+
     dbsession.add(request)
 
     try:
@@ -56,3 +59,9 @@ def process(dbsession: DbSession, record: bytes) -> None:
 
         if sequence_event is not None:
             log.debug('Inserting sequence event:\n%s', sequence_event)
+
+
+def process(dbsession: DbSession, record: bytes) -> None:
+    log.debug('Processing metric v2 record: %s', record)
+
+    do_process(dbsession, record)

--- a/azafea/event_processors/metrics/v2_import.py
+++ b/azafea/event_processors/metrics/v2_import.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2019 - Endless
+#
+# This file is part of Azafea
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+import logging
+
+from sqlalchemy.orm.session import Session as DbSession
+
+from .v2 import do_process
+
+
+log = logging.getLogger(__name__)
+
+
+# FIXME: Remove this once the import is successful
+def process(dbsession: DbSession, record: bytes) -> None:
+    log.debug('Importing metric v2 record: %s', record)
+
+    do_process(dbsession, record, discard_serialized=True)


### PR DESCRIPTION
We are going to import the historical data from Cassandra dumps. The
import process will be just like new incoming data: historical records
are inserted into Redis by the import script and Azafea pulls them from
there.

However, with this change, the import script will be able to put them in their own dedicated queue.

This serves 2 purposes:

1.  since Azafea pulls events from multiple queues, in the order they
    were configured, we can configure the import queue after the other
    ones so that incoming events are treated with priority;
2.  we can import the data slightly differently, without storing the
    serialized forms of the requests, to save disk space; this is ok because we already
    have the serialized data in the Cassandra dumps, and we will eventually remove this column anyway once we're confident in the processing and storage;
    
After some quick testing, we estimate this should save ~15% of disk
space.

This requires making the `metrics_request_v2.serialized` column optional though, which is also done in this branch.