### PR TITLE
Fix the Hack Clubhouse events

### DIFF
--- a/azafea/event_processors/metrics/tests/test_events.py
+++ b/azafea/event_processors/metrics/tests/test_events.py
@@ -145,3 +145,247 @@ def test_new_unknown_event():
     payload = GLib.Variant('mv', GLib.Variant('i', 43))
     event = TestUnknownEvent(payload=payload)
     assert event.payload_data == payload.get_data_as_bytes().get_data()
+
+
+@pytest.mark.parametrize('event_model_name, payload, expected_attrs', [
+    ('CacheIsCorrupt', None, {}),
+    ('CacheMetadataIsCorrupt', None, {}),
+    ('ControlCenterPanelOpened', GLib.Variant('s', 'privacy'), {'name': 'privacy'}),
+    (
+        'CPUInfo',
+        GLib.Variant('a(sqd)', [('Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz', 4, 2600.0)]),
+        {
+            'info': [{
+                'model': 'Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz',
+                'cores': 4,
+                'max_frequency': 2600.0,
+            }]
+        }
+    ),
+    (
+        'DiscoveryFeedClicked',
+        GLib.Variant('a{ss}', {'app_id': 'org.gnome.Totem', 'content_type': 'knowledge_video'}),
+        {'info': {'app_id': 'org.gnome.Totem', 'content_type': 'knowledge_video'}}
+    ),
+    (
+        'DiscoveryFeedClosed',
+        GLib.Variant('a{ss}', {'closed_by': 'buttonclose', 'time_open': '123'}),
+        {'info': {'closed_by': 'buttonclose', 'time_open': '123'}}
+    ),
+    (
+        'DiscoveryFeedOpened',
+        GLib.Variant('a{ss}', {'opened_by': 'shell_button', 'language': 'fr_FR.UTF-8'}),
+        {'info': {'opened_by': 'shell_button', 'language': 'fr_FR.UTF-8'}}
+    ),
+    ('DiskSpaceExtra', GLib.Variant('(uuu)', (30, 10, 20)), {'total': 30, 'used': 10, 'free': 20}),
+    ('DiskSpaceSysroot', GLib.Variant('(uuu)', (5, 3, 2)), {'total': 5, 'used': 3, 'free': 2}),
+    ('DualBootBooted', None, {}),
+    (
+        'EndlessApplicationUnmaximized',
+        GLib.Variant('s', 'org.gnome.Calendar'),
+        {'app_id': 'org.gnome.Calendar'}
+    ),
+    (
+        'HackClubhouseAchievement',
+        GLib.Variant('(ss)', ('id', 'name')),
+        {'achievement_id': 'id', 'achievement_name': 'name'}
+    ),
+    (
+        'HackClubhouseAchievementPoints',
+        GLib.Variant('(sii)', ('skillset', 0, 1)),
+        {'skillset': 'skillset', 'points': 0, 'new_points': 1}
+    ),
+    ('HackClubhouseChangePage', GLib.Variant('s', 'page'), {'page': 'page'}),
+    ('HackClubhouseEnterPathway', GLib.Variant('s', 'pathway'), {'pathway': 'pathway'}),
+    (
+        'HackClubhouseProgress',
+        GLib.Variant('a{sv}', {
+            'complete': GLib.Variant('b', True),
+            'quest': GLib.Variant('s', 'quest'),
+            'pathways': GLib.Variant('as', ['pathway1', 'pathway2']),
+            'progress': GLib.Variant('d', 100.0),
+        }),
+        {
+            'complete': True,
+            'quest': 'quest',
+            'pathways': ['pathway1', 'pathway2'],
+            'progress': 100.0,
+        }
+    ),
+    ('ImageVersion', GLib.Variant('s', 'image'), {'image_id': 'image'}),
+    (
+        'LaunchedEquivalentExistingFlatpak',
+        GLib.Variant('(sas)', ('org.glimpse_editor.Glimpse', ['photoshop.exe'])),
+        {'replacement_app_id': 'org.glimpse_editor.Glimpse', 'argv': ['photoshop.exe']}
+    ),
+    (
+        'LaunchedEquivalentInstallerForFlatpak',
+        GLib.Variant('(sas)', ('org.glimpse_editor.Glimpse', ['photoshop.exe'])),
+        {'replacement_app_id': 'org.glimpse_editor.Glimpse', 'argv': ['photoshop.exe']}
+    ),
+    (
+        'LaunchedExistingFlatpak',
+        GLib.Variant('(sas)', ('org.gnome.Calendar', ['gnome-calendar.deb'])),
+        {'replacement_app_id': 'org.gnome.Calendar', 'argv': ['gnome-calendar.deb']}
+    ),
+    (
+        'LaunchedInstallerForFlatpak',
+        GLib.Variant('(sas)', ('org.gnome.Calendar', ['gnome-calendar.deb'])),
+        {'replacement_app_id': 'org.gnome.Calendar', 'argv': ['gnome-calendar.deb']}
+    ),
+    (
+        'LinuxPackageOpened',
+        GLib.Variant('as', ['gnome-calendar.deb']),
+        {'argv': ['gnome-calendar.deb']}
+    ),
+    ('LiveUsbBooted', None, {}),
+    (
+        'Location',
+        GLib.Variant('(ddbdd)', (5.4, 6.5, False, 7.6, 8.7)),
+        {'latitude': 5.4, 'longitude': 6.5, 'altitude': None, 'accuracy': 8.7}
+    ),
+    (
+        'Location',
+        GLib.Variant('(ddbdd)', (1.0, 2.1, True, 3.2, 4.3)),
+        {'latitude': 1.0, 'longitude': 2.1, 'altitude': 3.2, 'accuracy': 4.3}
+    ),
+    (
+        'LocationLabel',
+        GLib.Variant('a{ss}', {'city': 'City', 'state': 'State', 'facility': 'Facility'}),
+        {'info': {'city': 'City', 'state': 'State', 'facility': 'Facility'}}
+    ),
+    (
+        'MissingCodec',
+        GLib.Variant('(ssssa{sv})', (
+            '1.16.0',
+            'Videos',
+            'decoder',
+            'audio/mp3',
+            {
+                'mpegaudioversion': GLib.Variant('i', 1),
+                'mpegversion': GLib.Variant('i', 1),
+                'layer': GLib.Variant('u', 3),
+            },
+        )),
+        {
+            'gstreamer_version': '1.16.0',
+            'app_name': 'Videos',
+            'type': 'decoder',
+            'name': 'audio/mp3',
+            'extra_info': {
+                'mpegaudioversion': 1,
+                'mpegversion': 1,
+                'layer': 3,
+            },
+        }
+    ),
+    (
+        'MonitorConnected',
+        GLib.Variant('(ssssiiay)', (
+            'Samsung Electric Company 22',
+            'SAM',
+            'S22E450',
+            'serial number is ignored',
+            500,
+            350,
+            b'edid data'
+        )),
+        {
+            'display_name': 'Samsung Electric Company 22',
+            'display_vendor': 'SAM',
+            'display_product': 'S22E450',
+            'display_width': 500,
+            'display_height': 350,
+            'edid': b'edid data',
+        }
+    ),
+    (
+        'MonitorDisconnected',
+        GLib.Variant('(ssssiiay)', (
+            'Samsung Electric Company 22',
+            'SAM',
+            'S22E450',
+            'serial number is ignored',
+            500,
+            350,
+            b'edid data'
+        )),
+        {
+            'display_name': 'Samsung Electric Company 22',
+            'display_vendor': 'SAM',
+            'display_product': 'S22E450',
+            'display_width': 500,
+            'display_height': 350,
+            'edid': b'edid data',
+        }
+    ),
+    ('NetworkId', GLib.Variant('u', 123456), {'network_id': 123456}),
+    (
+        'OSVersion',
+        GLib.Variant('(sss)', ('Endless', '3.5.3', 'obsolete and ignored')),
+        {'name': 'Endless', 'version': '3.5.3'}
+    ),
+    (
+        'ProgramDumpedCore',
+        GLib.Variant('a{sv}', {
+            'binary': GLib.Variant('s', '/app/bin/evolution'),
+            'signal': GLib.Variant('u', 11),
+        }),
+        {'info': {'binary': '/app/bin/evolution', 'signal': 11}}
+    ),
+    ('RAMSize', GLib.Variant('u', 32000), {'total': 32000}),
+    (
+        'ShellAppAddedToDesktop',
+        GLib.Variant('s', 'org.gnome.Calendar'),
+        {'app_id': 'org.gnome.Calendar'}
+    ),
+    (
+        'ShellAppRemovedFromDesktop',
+        GLib.Variant('s', 'org.gnome.Evolution'),
+        {'app_id': 'org.gnome.Evolution'}
+    ),
+    (
+        'UpdaterBranchSelected',
+        GLib.Variant('(sssb)', (
+            'Asustek Computer Inc.',
+            'To Be Filled By O.E.M.',
+            'os/eos/amd64/eos3',
+            False
+        )),
+        {
+            'hardware_vendor': 'ASUS',
+            'hardware_product': 'To Be Filled By O.E.M.',
+            'ostree_branch': 'os/eos/amd64/eos3',
+            'on_hold': False,
+        }
+    ),
+    ('Uptime', GLib.Variant('(xx)', (2, 1)), {'accumulated_uptime': 2, 'number_of_boots': 1}),
+    ('WindowsAppOpened', GLib.Variant('as', ['photoshop.exe']), {'argv': ['photoshop.exe']}),
+    ('WindowsLicenseTables', GLib.Variant('u', 0), {'tables': 0}),
+])
+def test_singular_event(event_model_name, payload, expected_attrs):
+    from azafea.event_processors.metrics import events
+
+    event_model = getattr(events, event_model_name)
+    maybe_payload = GLib.Variant('mv', payload)
+
+    event = event_model(payload=maybe_payload)
+
+    for attr_name, attr_value in expected_attrs.items():
+        assert getattr(event, attr_name) == attr_value
+
+
+@pytest.mark.parametrize('event_model_name, payload, expected_attrs', [
+    ('ShellAppIsOpen', GLib.Variant('s', 'org.gnome.Calendar'), {'app_id': 'org.gnome.Calendar'}),
+    ('UserIsLoggedIn', GLib.Variant('u', 1000), {'logged_in_user_id': 1000}),
+])
+def test_sequence_event(event_model_name, payload, expected_attrs):
+    from azafea.event_processors.metrics import events
+
+    event_model = getattr(events, event_model_name)
+    maybe_payload = GLib.Variant('mv', payload)
+
+    event = event_model(payload=maybe_payload)
+
+    for attr_name, attr_value in expected_attrs.items():
+        assert getattr(event, attr_name) == attr_value

--- a/azafea/event_processors/metrics/tests/test_utils.py
+++ b/azafea/event_processors/metrics/tests/test_utils.py
@@ -26,6 +26,7 @@ def test_get_asv_dict():
         'q': GLib.Variant('q', 1),
         't': GLib.Variant('t', 1985),
         's': GLib.Variant('s', '🎂️'),
+        'as': GLib.Variant('as', ['🌬️', '🎂️']),
     })
     assert get_asv_dict(variant) == {
         'b': True,
@@ -37,6 +38,7 @@ def test_get_asv_dict():
         'q': 1,
         't': 1985,
         's': '🎂️',
+        'as': ['🌬️', '🎂️'],
     }
 
 
@@ -45,7 +47,6 @@ def test_get_asv_dict():
     ('h', 512),
     ('o', '/path/to/nope'),
     ('g', 'no'),
-    ('as', ['nope']),
     ('mi', None),
     ('mv', GLib.Variant('i', 10)),
     ('(ii)', (10, 1)),

--- a/azafea/event_processors/metrics/utils.py
+++ b/azafea/event_processors/metrics/utils.py
@@ -107,6 +107,7 @@ _VARIANT_GETTERS = {
     't': lambda v: v.get_uint64(),
     'u': lambda v: v.get_uint32(),
     'x': lambda v: v.get_int64(),
+    'as': get_strings,
 }
 
 

--- a/azafea/event_processors/metrics/utils.py
+++ b/azafea/event_processors/metrics/utils.py
@@ -98,15 +98,15 @@ def get_variant(value: GLib.Variant) -> GLib.Variant:
 
 
 _VARIANT_GETTERS = {
-    'b': 'get_boolean',
-    'd': 'get_double',
-    'i': 'get_int32',
-    'n': 'get_int16',
-    'q': 'get_uint16',
-    's': 'get_string',
-    't': 'get_uint64',
-    'u': 'get_uint32',
-    'x': 'get_int64',
+    'b': lambda v: v.get_boolean(),
+    'd': lambda v: v.get_double(),
+    'i': lambda v: v.get_int32(),
+    'n': lambda v: v.get_int16(),
+    'q': lambda v: v.get_uint16(),
+    's': lambda v: v.get_string(),
+    't': lambda v: v.get_uint64(),
+    'u': lambda v: v.get_uint32(),
+    'x': lambda v: v.get_int64(),
 }
 
 
@@ -121,10 +121,12 @@ def get_asv_dict(value: GLib.Variant) -> Dict[str, Any]:
         type_string = v.get_type_string()
 
         try:
-            result[k] = getattr(v, _VARIANT_GETTERS[type_string])()
+            getter = _VARIANT_GETTERS[type_string]
 
         except KeyError:
             raise NotImplementedError(f"Can't unpack {type_string!r} variant in {value}")
+
+        result[k] = getter(v)
 
     return result
 

--- a/azafea/event_processors/metrics/utils.py
+++ b/azafea/event_processors/metrics/utils.py
@@ -73,6 +73,30 @@ class cached_property:  # pragma: no cover
 # End of the copy-pasted code
 
 
+# This assumes value is a `ay` variant, verify before calling this
+def get_bytes(value: GLib.Variant) -> bytes:
+    return bytes(v.get_byte() for v in get_child_values(value))
+
+
+# This assumes value is an array/tuple variant, verify before calling this
+def get_child_values(value: GLib.Variant) -> Generator[GLib.Variant, None, None]:
+    return (value.get_child_value(i) for i in range(value.n_children()))
+
+
+# This assumes value is an `as` variant, verify before calling this
+def get_strings(value: GLib.Variant) -> List[str]:
+    return [v.get_string() for v in get_child_values(value)]
+
+
+def get_variant(value: GLib.Variant) -> GLib.Variant:
+    # Some of the metric events (e.g UptimeEvent) have payload wrapped multiple times in variants,
+    # but others don't
+    while value.get_type_string() == 'v':
+        value = value.get_variant()
+
+    return value
+
+
 _VARIANT_GETTERS = {
     'b': 'get_boolean',
     'd': 'get_double',
@@ -103,30 +127,6 @@ def get_asv_dict(value: GLib.Variant) -> Dict[str, Any]:
             raise NotImplementedError(f"Can't unpack {type_string!r} variant in {value}")
 
     return result
-
-
-# This assumes value is a `ay` variant, verify before calling this
-def get_bytes(value: GLib.Variant) -> bytes:
-    return bytes(v.get_byte() for v in get_child_values(value))
-
-
-# This assumes value is an array/tuple variant, verify before calling this
-def get_child_values(value: GLib.Variant) -> Generator[GLib.Variant, None, None]:
-    return (value.get_child_value(i) for i in range(value.n_children()))
-
-
-# This assumes value is an `as` variant, verify before calling this
-def get_strings(value: GLib.Variant) -> List[str]:
-    return [v.get_string() for v in get_child_values(value)]
-
-
-def get_variant(value: GLib.Variant) -> GLib.Variant:
-    # Some of the metric events (e.g UptimeEvent) have payload wrapped multiple times in variants,
-    # but others don't
-    while value.get_type_string() == 'v':
-        value = value.get_variant()
-
-    return value
 
 
 # See the timestamp-algorithm.rst file in this directory for details


### PR DESCRIPTION
In #37 @danigm added new event models for the Hack Clubhouse application.

I didn't ask for tests to be added because the events looked simple enough, and didn't expect any surprise.

That was a failure on my part, because they couldn't actually work: the `HackClubhouseProgress` event uses `azafea.event_processors.metrics.utils.get_asv_dict()` to parse their payload, and one of the dict values is an `as` variant, which `get_asv_dict()` didn't know how to handle.

As a result, trying to push new `HackClubhouseProgress` events through Azafea would only lead to `NotImplementedError`s. :slightly_frowning_face: 

This merge requests fixes that by adding the missing implementation, and adds unit tests for the Hack Clubhouse events.

In fact, this adds unit tests for all the currently known events. Before, metrics events were only tested in integration tests, which are much harder to write. Hopefully being able to write unit tests more simply will avoid repeating this in the future.