### PR TITLE
metrics: Add hack mode metric

### DIFF
--- a/azafea/event_processors/metrics/events/__init__.py
+++ b/azafea/event_processors/metrics/events/__init__.py
@@ -223,6 +223,18 @@ class HackClubhouseEnterPathway(SingularEvent):
         return {'pathway': payload.get_string()}
 
 
+class HackClubhouseMode(SingularEvent):
+    __tablename__ = 'hack_clubhouse_mode'
+    __event_uuid__ = '7587784b-c3ed-4d74-b0fa-1023033698c0'
+    __payload_type__ = 'b'
+
+    active = Column(Boolean, nullable=False)
+
+    @staticmethod
+    def _get_fields_from_payload(payload: GLib.Variant) -> Dict[str, Any]:
+        return {'active': payload.get_boolean()}
+
+
 class HackClubhouseProgress(SingularEvent):
     __tablename__ = 'hack_clubhouse_progress'
     __event_uuid__ = '3a037364-9164-4b42-8c07-73bcc00902de'

--- a/azafea/event_processors/metrics/tests/test_events.py
+++ b/azafea/event_processors/metrics/tests/test_events.py
@@ -197,6 +197,7 @@ def test_new_unknown_event():
     ),
     ('HackClubhouseChangePage', GLib.Variant('s', 'page'), {'page': 'page'}),
     ('HackClubhouseEnterPathway', GLib.Variant('s', 'pathway'), {'pathway': 'pathway'}),
+    ('HackClubhouseMode', GLib.Variant('b', True), {'active': True}),
     (
         'HackClubhouseProgress',
         GLib.Variant('a{sv}', {


### PR DESCRIPTION
This patch adds a new metric emitted in the Hack clubhouse to track user
activation or deactivation of the Hack mode in EOS.