### PR TITLE
metrics: Ignore "user logged in" events with empty payloads

### DIFF
--- a/azafea/event_processors/metrics/events/_base.py
+++ b/azafea/event_processors/metrics/events/_base.py
@@ -55,6 +55,7 @@ IGNORED_EVENTS: Set[str] = {
 }
 IGNORED_EMPTY_PAYLOAD_ERRORS: Set[str] = {
     '9af2cc74-d6dd-423f-ac44-600a6eee2d96',
+    'add052be-7b2a-4959-81a5-a7f45062ee98',
 }
 
 
@@ -368,6 +369,9 @@ def new_sequence_event(request: Request, sequence_variant: GLib.Variant, dbsessi
                                started_at=started_at, stopped_at=stopped_at, payload=payload)
 
     except Exception as e:
+        if isinstance(e, EmptyPayloadError) and event_id in IGNORED_EMPTY_PAYLOAD_ERRORS:
+            return None
+
         log.exception('An error occured while processing the sequence:')
 
         # Mypy complains here, even though this should be fine:

--- a/azafea/event_processors/metrics/events/_base.py
+++ b/azafea/event_processors/metrics/events/_base.py
@@ -233,27 +233,26 @@ def new_singular_event(request: Request, event_variant: GLib.Variant, dbsession:
                                     event_relative_timestamp)
 
     try:
-        try:
-            event_model = SINGULAR_EVENT_MODELS[event_id]
+        event_model = SINGULAR_EVENT_MODELS[event_id]
 
-            # Mypy complains here, even though this should be fine:
-            # https://github.com/dropbox/sqlalchemy-stubs/issues/97
-            event = event_model(request=request, user_id=user_id,  # type: ignore
-                                occured_at=event_date, payload=payload)
+    except KeyError:
+        # Mypy complains here, even though this should be fine:
+        # https://github.com/dropbox/sqlalchemy-stubs/issues/97
+        event = UnknownSingularEvent(request=request, user_id=user_id,  # type: ignore
+                                     occured_at=event_date, event_id=event_id, payload=payload)
+        dbsession.add(event)
+        return event
 
-        except KeyError:
-            # Mypy complains here, even though this should be fine:
-            # https://github.com/dropbox/sqlalchemy-stubs/issues/97
-            event = UnknownSingularEvent(request=request, user_id=user_id,  # type: ignore
-                                         occured_at=event_date, event_id=event_id, payload=payload)
-
-        except EmptyPayloadError:
-            if event_id in IGNORED_EMPTY_PAYLOAD_ERRORS:
-                return None
-
-            raise
+    try:
+        # Mypy complains here, even though this should be fine:
+        # https://github.com/dropbox/sqlalchemy-stubs/issues/97
+        event = event_model(request=request, user_id=user_id,  # type: ignore
+                            occured_at=event_date, payload=payload)
 
     except Exception as e:
+        if isinstance(e, EmptyPayloadError) and event_id in IGNORED_EMPTY_PAYLOAD_ERRORS:
+            return None
+
         log.exception('An error occured while processing the event:')
 
         # Mypy complains here, even though this should be fine:
@@ -285,17 +284,20 @@ def new_aggregate_event(request: Request, event_variant: GLib.Variant, dbsession
     try:
         event_model = AGGREGATE_EVENT_MODELS[event_id]
 
-        # Mypy complains here, even though this should be fine:
-        # https://github.com/dropbox/sqlalchemy-stubs/issues/97
-        event = event_model(request=request, user_id=user_id, occured_at=event_date,  # type: ignore
-                            count=count, payload=payload)
-
     except KeyError:
         # Mypy complains here, even though this should be fine:
         # https://github.com/dropbox/sqlalchemy-stubs/issues/97
         event = UnknownAggregateEvent(request=request, user_id=user_id,  # type: ignore
                                       occured_at=event_date, count=count, event_id=event_id,
                                       payload=payload)
+        dbsession.add(event)
+        return event
+
+    try:
+        # Mypy complains here, even though this should be fine:
+        # https://github.com/dropbox/sqlalchemy-stubs/issues/97
+        event = event_model(request=request, user_id=user_id, occured_at=event_date,  # type: ignore
+                            count=count, payload=payload)
 
     except Exception as e:
         log.exception('An error occured while processing the aggregate:')
@@ -351,16 +353,19 @@ def new_sequence_event(request: Request, sequence_variant: GLib.Variant, dbsessi
     try:
         event_model = SEQUENCE_EVENT_MODELS[event_id]
 
-        # Mypy complains here, even though this should be fine:
-        # https://github.com/dropbox/sqlalchemy-stubs/issues/97
-        sequence = event_model(request=request, user_id=user_id,  # type: ignore
-                               started_at=started_at, stopped_at=stopped_at, payload=payload)
-
     except KeyError:
         # Mypy complains here, even though this should be fine:
         # https://github.com/dropbox/sqlalchemy-stubs/issues/97
         sequence = UnknownSequence(request=request, user_id=user_id,  # type: ignore
                                    event_id=event_id, payload=events)
+        dbsession.add(sequence)
+        return sequence
+
+    try:
+        # Mypy complains here, even though this should be fine:
+        # https://github.com/dropbox/sqlalchemy-stubs/issues/97
+        sequence = event_model(request=request, user_id=user_id,  # type: ignore
+                               started_at=started_at, stopped_at=stopped_at, payload=payload)
 
     except Exception as e:
         log.exception('An error occured while processing the sequence:')

--- a/azafea/event_processors/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/metrics/tests/integration/test_metrics_v2.py
@@ -1440,8 +1440,8 @@ class TestMetrics(IntegrationTest):
                     (
                         user_id,
                         UUID('9af2cc74-d6dd-423f-ac44-600a6eee2d96').bytes,
-                        1000000000,                    # event relative timestamp (1 sec)
-                        None,                          # empty payload
+                        1000000000,                        # event relative timestamp (1 sec)
+                        None,                              # empty payload
                     ),
                 ],
                 [],                                        # aggregate events

--- a/azafea/event_processors/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/metrics/tests/integration/test_metrics_v2.py
@@ -1416,8 +1416,9 @@ class TestMetrics(IntegrationTest):
             assert dbsession.query(UnknownSequence).count() == 0
 
     def test_ignored_empty_payload_errors(self):
-        from azafea.event_processors.metrics.events import Uptime
-        from azafea.event_processors.metrics.events._base import InvalidSingularEvent
+        from azafea.event_processors.metrics.events import Uptime, UserIsLoggedIn
+        from azafea.event_processors.metrics.events._base import (
+            InvalidSequence, InvalidSingularEvent)
         from azafea.event_processors.metrics.request import Request
 
         # Create the table
@@ -1444,7 +1445,22 @@ class TestMetrics(IntegrationTest):
                     ),
                 ],
                 [],                                        # aggregate events
-                []                                         # sequence events
+                [                                          # sequence events
+                    (
+                        user_id,
+                        UUID('add052be-7b2a-4959-81a5-a7f45062ee98').bytes,
+                        [                                  # events in the sequence
+                            (
+                                3000000000,                # event relative timestamp (3 secs)
+                                None,                      # INVALID: the payload should be a 'u'
+                            ),
+                            (
+                                120000000000,              # event relative timestamp (2 mins)
+                                None,
+                            ),
+                        ]
+                    ),
+                ]
             )
         )
 
@@ -1471,3 +1487,6 @@ class TestMetrics(IntegrationTest):
 
             assert dbsession.query(InvalidSingularEvent).count() == 0
             assert dbsession.query(Uptime).count() == 0
+
+            assert dbsession.query(InvalidSequence).count() == 0
+            assert dbsession.query(UserIsLoggedIn).count() == 0


### PR DESCRIPTION
A bug on client machines causes them to send those events for system
users in some cases, but with an empty payload.

There isn't much we can do about those, so let's discard them instead of
piling them up in the invalid table.