### PR TITLE
metrics: Fix hack clubhouse events

### DIFF
--- a/azafea/event_processors/metrics/tests/test_events.py
+++ b/azafea/event_processors/metrics/tests/test_events.py
@@ -203,7 +203,10 @@ def test_new_unknown_event():
         GLib.Variant('a{sv}', {
             'complete': GLib.Variant('b', True),
             'quest': GLib.Variant('s', 'quest'),
-            'pathways': GLib.Variant('as', ['pathway1', 'pathway2']),
+            'pathways': GLib.Variant('av', [
+                GLib.Variant('s', 'pathway1'),
+                GLib.Variant('s', 'pathway2'),
+            ]),
             'progress': GLib.Variant('d', 100.0),
         }),
         {
@@ -401,7 +404,10 @@ def test_hack_clubhouse_progress_event_with_unknown_key():
         'progress': GLib.Variant('d', 95.3),
         'complete': GLib.Variant('b', False),
         'quest': GLib.Variant('s', 'quest'),
-        'pathways': GLib.Variant('as', ['pathway2', 'pathway1']),
+        'pathways': GLib.Variant('av', [
+            GLib.Variant('s', 'pathway2'),
+            GLib.Variant('s', 'pathway1'),
+        ]),
         'unknown': GLib.Variant('s', 'ignored'),
     }))
 

--- a/azafea/event_processors/metrics/utils.py
+++ b/azafea/event_processors/metrics/utils.py
@@ -83,9 +83,9 @@ def get_child_values(value: GLib.Variant) -> Generator[GLib.Variant, None, None]
     return (value.get_child_value(i) for i in range(value.n_children()))
 
 
-# This assumes value is an `as` variant, verify before calling this
+# This assumes value is an `as` or `av<s>` variant, verify before calling this
 def get_strings(value: GLib.Variant) -> List[str]:
-    return [v.get_string() for v in get_child_values(value)]
+    return [get_variant(v).get_string() for v in get_child_values(value)]
 
 
 def get_variant(value: GLib.Variant) -> GLib.Variant:


### PR DESCRIPTION
The pathways attribute as sent by clients is an array of string
variants, not an array of strings.

I was also a bit unhappy with using the generic `get_asv_dict` function to parse this event when we know exactly what the payload is supposed to contain, so in this change I'm also making the code validate the payload.