### PR TITLE
Support per-queue commands 

### DIFF
--- a/azafea/cli/__init__.py
+++ b/azafea/cli/__init__.py
@@ -50,5 +50,14 @@ def run_command(*argv: str) -> None:
     # Core commands
     commands.register_commands(subs)
 
+    # Per-queue plugin commands
+    for queue_name, queue_config in config.queues.items():
+        if queue_config.cli is not None:
+            queue_parser = subs.add_parser(
+                queue_name, help=f'Commands related to the {queue_name} queue processor')
+            queue_subs = queue_parser.add_subparsers(title='subcommands', dest='subcommand',
+                                                     required=True)
+            queue_config.cli(queue_subs)
+
     args = parser.parse_args(argv)
     args.subcommand(config, args)

--- a/azafea/cli/__init__.py
+++ b/azafea/cli/__init__.py
@@ -7,6 +7,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
+import argparse
 import logging
 
 from . import commands
@@ -18,14 +19,23 @@ from ..logging import setup_logging
 log = logging.getLogger(__name__)
 
 
+def _get_parser(*, add_help: bool = False) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog='azafea', add_help=add_help,
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument('-c', '--config', default='/etc/azafea/config.toml',
+                        help='Optional path to a configuration file, if needed')
+
+    return parser
+
+
 def run_command(*argv: str) -> None:
+    parser = _get_parser(add_help=False)
+    base_args, remainder = parser.parse_known_args(argv)
     setup_logging(verbose=False)
 
-    parser = commands.get_parser()
-    args = parser.parse_args(argv)
-
     try:
-        config = Config.from_file(args.config)
+        config = Config.from_file(base_args.config)
 
     except InvalidConfigurationError as e:
         log.error(e)
@@ -34,4 +44,11 @@ def run_command(*argv: str) -> None:
 
     setup_logging(verbose=config.main.verbose)
 
+    parser = _get_parser(add_help=True)
+    subs = parser.add_subparsers(title='subcommands', dest='subcommand', required=True)
+
+    # Core commands
+    commands.register_commands(subs)
+
+    args = parser.parse_args(argv)
     args.subcommand(config, args)

--- a/azafea/cli/commands.py
+++ b/azafea/cli/commands.py
@@ -22,15 +22,7 @@ from .errors import ConnectionErrorExit, NoEventQueueExit, UnknownErrorExit
 log = logging.getLogger(__name__)
 
 
-def get_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog='azafea',
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-    parser.add_argument('-c', '--config', default='/etc/azafea/config.toml',
-                        help='Optional path to a configuration file, if needed')
-
-    subs = parser.add_subparsers(title='subcommands', dest='subcommand', required=True)
-
+def register_commands(subs: argparse._SubParsersAction) -> None:
     dropdb = subs.add_parser('dropdb', help='Drop the tables in the database')
     dropdb.set_defaults(subcommand=do_dropdb)
 
@@ -49,8 +41,6 @@ def get_parser() -> argparse.ArgumentParser:
 
     run = subs.add_parser('run', help='Run azafea')
     run.set_defaults(subcommand=do_run)
-
-    return parser
 
 
 def do_dropdb(config: Config, args: argparse.Namespace) -> None:

--- a/azafea/config/__init__.py
+++ b/azafea/config/__init__.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm.session import Session as DbSession
 import toml
 
 from ._validators import is_boolean, is_non_empty_string, is_strictly_positive_integer
-from ..utils import get_cpu_count, get_handler, wrap_with_repr
+from ..utils import get_callable, get_cpu_count, wrap_with_repr
 
 
 log = logging.getLogger(__name__)
@@ -135,7 +135,7 @@ class Queue(_Base):
     @validator('handler', pre=True)
     def get_handler(cls, value: str) -> Callable[[DbSession, bytes], None]:
         try:
-            handler = get_handler(value)
+            handler = get_callable(value, 'process')
 
         except ImportError:
             raise ValueError(f'Could not import handler module {value!r}')

--- a/azafea/processor.py
+++ b/azafea/processor.py
@@ -82,16 +82,16 @@ class Processor(Process):
 
             log.debug('{%s} Pulled %s from the %s queue', self.name, value, queue_name)
 
-            queue_handler = self.config.queues[queue_name].handler
+            queue_processor = self.config.queues[queue_name].processor
             log.debug('{%s} Processing event from the %s queue with %s',
-                      self.name, queue_name, get_fqdn(queue_handler))
+                      self.name, queue_name, get_fqdn(queue_processor))
 
             try:
                 with self._db as dbsession:
-                    queue_handler(dbsession, value)
+                    queue_processor(dbsession, value)
 
             except Exception:
                 log.exception('{%s} An error occured while processing an event from the %s queue '
                               'with %s\nDetails:',
-                              self.name, queue_name, get_fqdn(queue_handler))
+                              self.name, queue_name, get_fqdn(queue_processor))
                 self._redis.lpush(f'errors-{queue_name}', value)

--- a/azafea/tests/integration/__init__.py
+++ b/azafea/tests/integration/__init__.py
@@ -112,7 +112,7 @@ class IntegrationTest:
         modules_to_deregister = []
 
         for queue_config in self.config.queues.values():
-            handler_root = queue_config.handler.__module__.rsplit('.', 1)[0]
+            handler_root = queue_config.handler.rsplit('.', 1)[0]
 
             for module in sys.modules:
                 if module.startswith(handler_root):

--- a/azafea/tests/test_cli.py
+++ b/azafea/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_dropdb(capfd, monkeypatch, make_config_file):
         def drop_all(self):
             print('Dropping the tables…')
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -30,7 +30,7 @@ def test_dropdb(capfd, monkeypatch, make_config_file):
     config_file = make_config_file({'queues': {'some-queue': {'handler': 'azafea.tests.test_cli'}}})
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         m.setattr(azafea.cli.commands, 'Db', MockDb)
         azafea.cli.run_command('-c', str(config_file), 'dropdb')
 
@@ -67,7 +67,7 @@ def test_initdb(capfd, monkeypatch, make_config_file):
         def create_all(self):
             print('Creating the tables…')
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -76,7 +76,7 @@ def test_initdb(capfd, monkeypatch, make_config_file):
     config_file = make_config_file({'queues': {'some-queue': {'handler': 'azafea.tests.test_cli'}}})
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         m.setattr(azafea.cli.commands, 'Db', MockDb)
         azafea.cli.run_command('-c', str(config_file), 'initdb')
 
@@ -106,7 +106,7 @@ def test_initdb_no_event_queue(capfd, make_config_file):
 
 
 def test_print_config(capfd, monkeypatch, make_config_file):
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -120,7 +120,7 @@ def test_print_config(capfd, monkeypatch, make_config_file):
     })
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         azafea.cli.run_command('-c', str(config_file), 'print-config')
 
     capture = capfd.readouterr()
@@ -196,7 +196,7 @@ def test_replay_errors(capfd, monkeypatch, make_config_file):
     def mock_redis(*args, **kwargs):
         return redis
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -208,7 +208,7 @@ def test_replay_errors(capfd, monkeypatch, make_config_file):
 
     with monkeypatch.context() as m:
         m.setattr(azafea.cli.commands, 'Redis', mock_redis)
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         azafea.cli.run_command('-c', str(config_file), 'replay-errors', 'some-queue')
 
     assert redis._queues == {
@@ -242,7 +242,7 @@ def test_replay_errors_no_event_queue(capfd, make_config_file):
 
 
 def test_replay_errors_unknown_queue(capfd, monkeypatch, make_config_file):
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -253,7 +253,7 @@ def test_replay_errors_unknown_queue(capfd, monkeypatch, make_config_file):
     })
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
 
         with pytest.raises(azafea.cli.errors.NoEventQueueExit):
             azafea.cli.run_command('-c', str(config_file), 'replay-errors', 'other-queue')
@@ -290,7 +290,7 @@ def test_replay_errors_stopped_early(capfd, monkeypatch, make_config_file):
     def mock_redis(*args, **kwargs):
         return redis
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -302,7 +302,7 @@ def test_replay_errors_stopped_early(capfd, monkeypatch, make_config_file):
 
     with monkeypatch.context() as m:
         m.setattr(azafea.cli.commands, 'Redis', mock_redis)
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         azafea.cli.run_command('-c', str(config_file), 'replay-errors', 'some-queue')
 
     assert redis._queues == {
@@ -341,7 +341,7 @@ def test_replay_errors_fail_to_push(capfd, monkeypatch, make_config_file):
     def mock_redis(*args, **kwargs):
         return redis
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -353,7 +353,7 @@ def test_replay_errors_fail_to_push(capfd, monkeypatch, make_config_file):
 
     with monkeypatch.context() as m:
         m.setattr(azafea.cli.commands, 'Redis', mock_redis)
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
 
         with pytest.raises(azafea.cli.errors.UnknownErrorExit):
             azafea.cli.run_command('-c', str(config_file), 'replay-errors', 'some-queue')
@@ -375,7 +375,7 @@ def test_run(capfd, monkeypatch, make_config_file):
         def main(self):
             print('Running the mock controller…')
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -384,7 +384,7 @@ def test_run(capfd, monkeypatch, make_config_file):
     config_file = make_config_file({'queues': {'some-queue': {'handler': 'azafea.tests.test_cli'}}})
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         m.setattr(azafea.cli.commands, 'Controller', MockController)
         azafea.cli.run_command('-c', str(config_file), 'run')
 
@@ -415,7 +415,7 @@ def test_run_no_event_queue(capfd, make_config_file):
 
 
 def test_run_redis_connection_error(capfd, monkeypatch, make_config_file):
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -428,7 +428,7 @@ def test_run_redis_connection_error(capfd, monkeypatch, make_config_file):
     })
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
 
         with pytest.raises(azafea.cli.errors.ConnectionErrorExit):
             azafea.cli.run_command('-c', str(config_file), 'run')
@@ -450,7 +450,7 @@ def test_run_postgresql_connection_error(capfd, monkeypatch, make_config_file):
         def connect(self):
             pass
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         def process(*args, **kwargs):
             pass
 
@@ -463,7 +463,7 @@ def test_run_postgresql_connection_error(capfd, monkeypatch, make_config_file):
     })
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         m.setattr(azafea.processor, 'Redis', MockRedis)
 
         with pytest.raises(azafea.cli.errors.ConnectionErrorExit):

--- a/azafea/tests/test_config.py
+++ b/azafea/tests/test_config.py
@@ -63,11 +63,11 @@ def test_override(monkeypatch, make_config):
     def process(*args, **kwargs):
         pass
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         return process
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         config = make_config({
             'main': {'number_of_workers': 1},
             'redis': {'port': 42},

--- a/azafea/tests/test_config.py
+++ b/azafea/tests/test_config.py
@@ -314,7 +314,7 @@ def test_add_queue_with_nonexistent_handler_module(make_config):
         make_config({'queues': {'some-queue': {'handler': 'no.such.module'}}})
 
     assert ('Invalid configuration:\n'
-            f"* queues.some-queue.handler: Could not import handler module 'no.such.module'"
+            f"* queues.some-queue.handler: Could not import module 'no.such.module'"
             ) in str(exc_info.value)
 
 
@@ -323,7 +323,7 @@ def test_add_queue_with_invalid_handler_module(make_config):
         make_config({'queues': {'some-queue': {'handler': 'azafea'}}})
 
     assert ('Invalid configuration:\n'
-            f"* queues.some-queue.handler: Handler 'azafea' is missing a \"process\" function"
+            f"* queues.some-queue.handler: Module 'azafea' is missing a 'process' function"
             ) in str(exc_info.value)
 
 

--- a/azafea/tests/test_processor.py
+++ b/azafea/tests/test_processor.py
@@ -92,11 +92,11 @@ def test_start_then_sigint(capfd, monkeypatch, make_config, mock_sessionmaker):
     def process(*args, **kwargs):
         pass
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         return process
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         config = make_config({
             'main': {'verbose': True},
             'queues': {'some-queue': {'handler': 'azafea.tests.test_processor'}},
@@ -127,11 +127,11 @@ def test_start_then_sigterm(capfd, monkeypatch, make_config, mock_sessionmaker):
     def process(*args, **kwargs):
         pass
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         return process
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         config = make_config({
             'main': {'verbose': True},
             'queues': {'some-queue': {'handler': 'azafea.tests.test_processor'}},
@@ -162,11 +162,11 @@ def test_process_with_error(capfd, monkeypatch, make_config, mock_sessionmaker):
     def failing_process(*args, **kwargs):
         raise ValueError('Oh no!')
 
-    def mock_get_handler(module):
+    def mock_get_callable(module_name, callable_name):
         return failing_process
 
     with monkeypatch.context() as m:
-        m.setattr(azafea.config, 'get_handler', mock_get_handler)
+        m.setattr(azafea.config, 'get_callable', mock_get_callable)
         config = make_config({
             'main': {'verbose': True},
             'queues': {'some-queue': {'handler': 'azafea.tests.test_processor'}},

--- a/azafea/tests/test_utils.py
+++ b/azafea/tests/test_utils.py
@@ -41,20 +41,20 @@ def test_get_fqdn(module, name, expected):
     assert azafea.utils.get_fqdn(f) == expected
 
 
-def test_get_handler():
-    handler = azafea.utils.get_handler('azafea.tests.test_utils')
+def test_get_callable():
+    handler = azafea.utils.get_callable('azafea.tests.test_utils', 'process')
 
     assert handler == process
 
 
-def test_get_nonexistent_handler_module():
+def test_get_nonexistent_callable_module():
     with pytest.raises(ImportError):
-        azafea.utils.get_handler('no.such.module')
+        azafea.utils.get_callable('no.such.module', 'process')
 
 
-def test_get_invalid_handler_module():
+def test_get_invalid_callable_module():
     with pytest.raises(AttributeError):
-        azafea.utils.get_handler('azafea')
+        azafea.utils.get_callable('azafea.tests.test_utils', 'no_such_method')
 
 
 def test_wrap_with_repr(capfd):

--- a/azafea/tests/test_utils.py
+++ b/azafea/tests/test_utils.py
@@ -55,22 +55,3 @@ def test_get_nonexistent_callable_module():
 def test_get_invalid_callable_module():
     with pytest.raises(AttributeError):
         azafea.utils.get_callable('azafea.tests.test_utils', 'no_such_method')
-
-
-def test_wrap_with_repr(capfd):
-    def some_function(some, arguments):
-        """An excellent doc string"""
-        print(f'Calling some_function({some!r}, {arguments!r})')
-
-    assert repr(some_function) != 'Some super repr'
-
-    wrapped = azafea.utils.wrap_with_repr(some_function, 'Some super repr')
-    assert repr(wrapped) == 'Some super repr'
-    assert wrapped.__doc__ == 'An excellent doc string'
-    assert wrapped.__module__ == 'azafea.tests.test_utils'
-    assert wrapped.__name__ == 'some_function'
-
-    wrapped('foo', 42)
-
-    capture = capfd.readouterr()
-    assert "Calling some_function('foo', 42)" in capture.out

--- a/azafea/utils.py
+++ b/azafea/utils.py
@@ -25,10 +25,10 @@ def get_fqdn(f: Callable) -> str:
     return f'{f.__module__}.{f.__name__}'
 
 
-def get_handler(module: str) -> Callable:
-    handler_module = import_module(module)
+def get_callable(module_name: str, callable_name: str) -> Callable:
+    module = import_module(module_name)
 
-    return handler_module.process  # type: ignore
+    return getattr(module, callable_name)
 
 
 def wrap_with_repr(f: Callable, repr_: str) -> Callable:

--- a/azafea/utils.py
+++ b/azafea/utils.py
@@ -9,7 +9,7 @@
 
 from importlib import import_module
 import os
-from typing import Any, Callable, TypeVar
+from typing import Callable
 
 
 # The Python documentation for os.cpu_count() says:
@@ -29,24 +29,3 @@ def get_callable(module_name: str, callable_name: str) -> Callable:
     module = import_module(module_name)
 
     return getattr(module, callable_name)
-
-
-def wrap_with_repr(f: Callable, repr_: str) -> Callable:
-    WrappedReturnType = TypeVar('WrappedReturnType')
-
-    class wrapper:
-        def __init__(self, to_wrap: Callable[..., WrappedReturnType]):
-            self.wrapped = to_wrap
-            self.repr = repr_
-
-            self.__doc__ = self.wrapped.__doc__
-            self.__module__ = self.wrapped.__module__
-            self.__name__ = self.wrapped.__name__
-
-        def __repr__(self) -> str:
-            return self.repr
-
-        def __call__(self, *args: Any, **kwargs: Any) -> WrappedReturnType:
-            return self.wrapped(*args, **kwargs)
-
-    return wrapper(f)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -145,9 +145,12 @@ Each queue is its own table with its own options:
   The dotted-path of the Python module responsible to process the events pulled
   from this queue. Azafea will try importing that module.
 
-  Make sure you read :doc:`how to write event handler modules <event-handlers>`
+  Make sure you read :doc:`how to write event handler modules <queue-plugins>`
   for all the details on what Azafea expects from them.
 
 So in the above example, Azafea will pull events from 2 Redis queues, one named
 ``"be"`` and one named ``"te"``, and will pass them to the ``a.python.module``
 handler for the former and to the ``another.python.module`` for the latter.
+
+Azafea will also provide the subcommands registered by both queues in their
+respective module.

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -19,7 +19,7 @@ incoming format, how to deserialize them, what to do with them and finally how
 to store them in PostgreSQL.
 
 That makes Azafea flexible so it can adapt to the needs of various
-organizations: you can :doc:`write your own event handlers <event-handlers>`
+organizations: you can :doc:`write your own event handlers <queue-plugins>`
 which will process your events just the way you want.
 
 All of this is piloted by :doc:`the configuration file <configuration>`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,5 +18,5 @@ PostgreSQL, where they can be queried and visualized.
    design
    install
    configuration
-   event-handlers
+   queue-plugins
    contribute


### PR DESCRIPTION
This first does some refactoring then adds the capability for queue plugins to provide their own CLI subcommands to the main `azafea` command.

No such command is provided, they will come in future pull requests.