### PR TITLE
metrics: Remove most of the code for aggregate events

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -35,6 +35,7 @@
         },
         "pycairo": {
             "hashes": [
+                "sha256:c392a015bd46753bdcb89d8d83aa493ffc05ea48266249dab735be6ff76d808e",
                 "sha256:dcb853fd020729516e8828ad364084e752327d4cff8505d20b13504b32b16531"
             ],
             "version": "==1.18.2"
@@ -110,10 +111,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
             ],
-            "version": "==2019.9.11"
+            "version": "==2019.11.28"
         },
         "chardet": {
             "hashes": [
@@ -329,10 +330,10 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
-                "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
+                "sha256:83ec6c6133ca6b529b7ff5aa826328fd14b5bb02a58c37f4f06384e96a0f94ab",
+                "sha256:b7949de3d396836085fea596998b135a22610bbcc4f2abfe9e448e44cbc58388"
             ],
-            "version": "==2.4.2"
+            "version": "==2.5.1"
         },
         "pyparsing": {
             "hashes": [
@@ -343,11 +344,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1897d74f60a5d8be02e06d708b41bf2445da2ee777066bd68edf14474fc201eb",
-                "sha256:f6a567e20c04259d41adce9a360bd8991e6aa29dd9695c5e6bd25a9779272673"
+                "sha256:63344a2e3bce2e4d522fd62b4fdebb647c019f1f9e4ca075debbd13219db4418",
+                "sha256:f67403f33b2b1d25a6756184077394167fe5e2f9d8bdaab30707d19ccec35427"
             ],
             "index": "pypi",
-            "version": "==5.3.0"
+            "version": "==5.3.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -453,7 +454,7 @@
         },
         "sqlalchemy-stubs": {
             "git": "https://github.com/dropbox/sqlalchemy-stubs.git",
-            "ref": "6d07636e47c9331b15de5baef40af82dcaed48f2"
+            "ref": "3a376f97f0d62c86baf74d38e9ffabeda9cd70cb"
         },
         "typed-ast": {
             "hashes": [

--- a/azafea/event_processors/metrics/tests/test_events.py
+++ b/azafea/event_processors/metrics/tests/test_events.py
@@ -399,7 +399,7 @@ def test_hack_clubhouse_progress_event_with_unknown_key():
     # it to be sure.
     from azafea.event_processors.metrics.events import HackClubhouseProgress
 
-    # Make an invalid payload with missing keys
+    # Make an invalid payload with extra keys
     payload = GLib.Variant('mv', GLib.Variant('a{sv}', {
         'progress': GLib.Variant('d', 95.3),
         'complete': GLib.Variant('b', False),

--- a/azafea/event_processors/metrics/v2/handler.py
+++ b/azafea/event_processors/metrics/v2/handler.py
@@ -50,9 +50,7 @@ def do_process(dbsession: DbSession, record: bytes, discard_serialized: bool = F
 
     for event_variant in request_builder.aggregates:
         aggregate_event = new_aggregate_event(request, event_variant, dbsession)
-
-        if aggregate_event is not None:
-            log.debug('Inserting aggregate metric:\n%s', aggregate_event)
+        log.debug('Inserting aggregate metric:\n%s', aggregate_event)
 
     for event_variant in request_builder.sequences:
         sequence_event = new_sequence_event(request, event_variant, dbsession)


### PR DESCRIPTION
After this commit, all aggregate events will always be treated as
unknown.

I've had enough of this unused, untested code. We can bring it back when
we actually have some aggregate events.
