### PR TITLE
metrics: Make queries simpler

### DIFF
--- a/azafea/event_processors/metrics/machine.py
+++ b/azafea/event_processors/metrics/machine.py
@@ -7,10 +7,11 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.schema import Column
 from sqlalchemy.types import Integer, Unicode
 
-from azafea.model import Base
+from azafea.model import Base, DbSession
 
 
 class Machine(Base):
@@ -19,3 +20,10 @@ class Machine(Base):
     id = Column(Integer, primary_key=True)
     machine_id = Column(Unicode(32), nullable=False, unique=True)
     image_id = Column(Unicode, nullable=False)
+
+
+def insert_machine(dbsession: DbSession, machine_id: str, image_id: str) -> None:
+    stmt = insert(Machine.__table__).values(machine_id=machine_id, image_id=image_id)
+    stmt = stmt.on_conflict_do_nothing()
+
+    dbsession.connection().execute(stmt)

--- a/azafea/event_processors/metrics/machine.py
+++ b/azafea/event_processors/metrics/machine.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2019 - Endless
+#
+# This file is part of Azafea
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+from sqlalchemy.schema import Column
+from sqlalchemy.types import Integer, Unicode
+
+from azafea.model import Base
+
+
+class Machine(Base):
+    __tablename__ = 'metrics_machine'
+
+    id = Column(Integer, primary_key=True)
+    machine_id = Column(Unicode(32), nullable=False, unique=True)
+    image_id = Column(Unicode, nullable=False)

--- a/azafea/event_processors/metrics/tests/integration/test_metrics_db_functions.py
+++ b/azafea/event_processors/metrics/tests/integration/test_metrics_db_functions.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2019 - Endless
+#
+# This file is part of Azafea
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+from datetime import datetime, timezone
+
+from gi.repository import GLib
+
+import pytest
+
+from sqlalchemy.sql.expression import func
+
+from azafea.tests.integration import IntegrationTest
+
+
+class TestMetrics(IntegrationTest):
+    handler_module = 'azafea.event_processors.metrics.v2'
+
+    @pytest.fixture(autouse=True)
+    def drop_functions(self):
+        yield
+
+        with self.db as dbsession:
+            dbsession.execute('DROP FUNCTION get_image_product')
+            dbsession.execute('DROP FUNCTION get_image_personality')
+
+            # We have to do this explicitly because the model Base is imported long before we have
+            # a chance to run the migratedb command
+            dbsession.execute('DROP TABLE alembic_version')
+
+    def test_get_image_product_personality(self):
+        from azafea.event_processors.metrics.events import ImageVersion
+        from azafea.event_processors.metrics.machine import Machine
+        from azafea.event_processors.metrics.request import Request
+
+        self.run_subcommand('migratedb')
+        self.ensure_tables(ImageVersion, Machine, Request)
+
+        image_id = 'oem-os1.0-arch.base'
+        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        # Add a request with an image version
+        with self.db as dbsession:
+            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine',
+                              send_number=0)
+            dbsession.add(request)
+
+            dbsession.add(ImageVersion(request=request, user_id=1001, occured_at=occured_at,
+                                       payload=GLib.Variant('mv', GLib.Variant('s', image_id))))
+
+        # Ensure this machine has the right product/personality
+        with self.db as dbsession:
+            product = dbsession.query(func.get_image_product(Request.machine_id)).one()[0]
+            assert product == 'oem'
+            personality = dbsession.query(func.get_image_personality(Request.machine_id)).one()[0]
+            assert personality == 'base'
+
+    def test_get_image_product_personality_without_machine_mapping(self):
+        from azafea.event_processors.metrics.events import ImageVersion
+        from azafea.event_processors.metrics.machine import Machine
+        from azafea.event_processors.metrics.request import Request
+
+        self.run_subcommand('migratedb')
+        self.ensure_tables(ImageVersion, Machine, Request)
+
+        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        # Add a request without an image version
+        with self.db as dbsession:
+            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine',
+                              send_number=0)
+            dbsession.add(request)
+
+        # Ensure this machine has no product/personality
+        with self.db as dbsession:
+            product = dbsession.query(func.get_image_product(Request.machine_id)).one()[0]
+            assert product is None
+            personality = dbsession.query(func.get_image_personality(Request.machine_id)).one()[0]
+            assert personality is None

--- a/azafea/event_processors/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/metrics/tests/integration/test_metrics_v2.py
@@ -178,7 +178,18 @@ class TestMetrics(IntegrationTest):
 
         # Create the table
         self.run_subcommand('initdb')
-        self.ensure_tables(Request, LiveUsbBooted, Uptime, UnknownSingularEvent)
+        self.ensure_tables(
+            Request, Machine, InvalidSingularEvent, UnknownSingularEvent,
+            CacheIsCorrupt, CacheMetadataIsCorrupt, ControlCenterPanelOpened, CPUInfo,
+            DiscoveryFeedClicked, DiscoveryFeedClosed, DiscoveryFeedOpened, DiskSpaceExtra,
+            DiskSpaceSysroot, DualBootBooted, EndlessApplicationUnmaximized, ImageVersion,
+            LaunchedEquivalentExistingFlatpak, LaunchedEquivalentInstallerForFlatpak,
+            LaunchedExistingFlatpak, LaunchedInstallerForFlatpak, LinuxPackageOpened, LiveUsbBooted,
+            Location, LocationLabel, MissingCodec, MonitorConnected, MonitorDisconnected, NetworkId,
+            OSVersion, ProgramDumpedCore, RAMSize, ShellAppAddedToDesktop,
+            ShellAppRemovedFromDesktop, UpdaterBranchSelected, Uptime, WindowsAppOpened,
+            WindowsLicenseTables,
+        )
 
         # Build a request as it would have been sent to us
         now = datetime.now(tz=timezone.utc)

--- a/azafea/event_processors/metrics/v2/migrations/33c19f68197d_add_the_machine_mapping_table.py
+++ b/azafea/event_processors/metrics/v2/migrations/33c19f68197d_add_the_machine_mapping_table.py
@@ -1,0 +1,31 @@
+# type: ignore
+
+"""Add the machine mapping table
+
+Revision ID: 33c19f68197d
+Revises: 1135ef61f61e
+Create Date: 2019-12-11 11:09:39.562184
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '33c19f68197d'
+down_revision = '1135ef61f61e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('metrics_machine',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('machine_id', sa.Unicode(length=32), nullable=False),
+                    sa.Column('image_id', sa.Unicode(), nullable=False),
+                    sa.PrimaryKeyConstraint('id', name=op.f('pk_metrics_machine')),
+                    sa.UniqueConstraint('machine_id', name=op.f('uq_metrics_machine_machine_id')))
+
+
+def downgrade():
+    op.drop_table('metrics_machine')

--- a/azafea/event_processors/metrics/v2/migrations/7f4c0154d6cd_add_image_functions.py
+++ b/azafea/event_processors/metrics/v2/migrations/7f4c0154d6cd_add_image_functions.py
@@ -1,0 +1,52 @@
+# type: ignore
+
+"""Add image functions
+
+Revision ID: 7f4c0154d6cd
+Revises: 33c19f68197d
+Create Date: 2019-12-11 14:30:48.877166
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7f4c0154d6cd'
+down_revision = '33c19f68197d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('CREATE FUNCTION get_image_personality(_machine_id text) RETURNS text\n'
+               '  LANGUAGE plpgsql IMMUTABLE\n'
+               '  AS $$\n'
+               '    BEGIN\n'
+               '      RETURN (\n'
+               "        SELECT reverse(split_part(reverse(image_id), '.', 1)) AS personality\n"
+               '          FROM metrics_machine\n'
+               '          WHERE metrics_machine.machine_id = _machine_id\n'
+               '      ) ;\n'
+               '    END;\n'
+               '  $$;')
+    op.create_index(op.f('ix_metrics_request_v2_image_personality'), 'metrics_request_v2',
+                    [sa.text('get_image_personality(machine_id)')], unique=False)
+    op.execute('CREATE FUNCTION get_image_product(_machine_id text) RETURNS text\n'
+               '  LANGUAGE plpgsql IMMUTABLE\n'
+               '  AS $$\n'
+               '    BEGIN\n'
+               '      RETURN (\n'
+               "        SELECT split_part(image_id, '-', 1) AS product\n"
+               '          FROM metrics_machine\n'
+               '          WHERE metrics_machine.machine_id = _machine_id\n'
+               '      ) ;\n'
+               '    END;\n'
+               '  $$;')
+    op.create_index(op.f('ix_metrics_request_v2_image_product'), 'metrics_request_v2',
+                    [sa.text('get_image_product(machine_id)')], unique=False)
+
+
+def downgrade():
+    op.execute('DROP FUNCTION get_image_product;')
+    op.execute('DROP FUNCTION get_image_personality;')


### PR DESCRIPTION
Most queries we want to run on the database are based on the image "product" and "personality".

At the moment that implies joining the metrics_request_v2 and image_version tables, filtering by the result of a function you must write in the query, then joining that with the tables you want to actually query.

This branch makes it significantly easier by adding a machine/image mapping, and a couple of functions to get the image product and personality for a given request.

This will also be the base of the row-level security for the Endless deployment: a given user will only have access to the requests corresponding to machines running a given product/personality. (#46)