### PR TITLE
Misc fixups

### DIFF
--- a/azafea/event_processors/activation/v1/cli.py
+++ b/azafea/event_processors/activation/v1/cli.py
@@ -24,7 +24,8 @@ log = logging.getLogger(__name__)
 
 def register_commands(subs: argparse._SubParsersAction) -> None:
     normalize_vendors = subs.add_parser('normalize-vendors',
-                                        help='Normalize the vendors in existing records')
+                                        help='Normalize the vendors in existing records',
+                                        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     normalize_vendors.add_argument('--chunk-size', type=int, default=5000,
                                    help='The size of the chunks to operate on')
     normalize_vendors.set_defaults(subcommand=do_normalize_vendors)

--- a/azafea/event_processors/metrics/v2/cli.py
+++ b/azafea/event_processors/metrics/v2/cli.py
@@ -38,17 +38,20 @@ log = logging.getLogger(__name__)
 
 def register_commands(subs: argparse._SubParsersAction) -> None:
     normalize_vendors = subs.add_parser('normalize-vendors',
-                                        help='Normalize the vendors in existing records')
+                                        help='Normalize the vendors in existing records',
+                                        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     normalize_vendors.add_argument('--chunk-size', type=int, default=5000,
                                    help='The size of the chunks to operate on')
     normalize_vendors.set_defaults(subcommand=do_normalize_vendors)
 
-    replay_invalid = subs.add_parser('replay-invalid', help='Replay invalid events')
+    replay_invalid = subs.add_parser('replay-invalid', help='Replay invalid events',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     replay_invalid.add_argument('--chunk-size', type=int, default=5000,
                                 help='The size of the chunks to operate on')
     replay_invalid.set_defaults(subcommand=do_replay_invalid)
 
-    replay_unknown = subs.add_parser('replay-unknown', help='Replay unknown events')
+    replay_unknown = subs.add_parser('replay-unknown', help='Replay unknown events',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     replay_unknown.add_argument('--chunk-size', type=int, default=5000,
                                 help='The size of the chunks to operate on')
     replay_unknown.set_defaults(subcommand=do_replay_unknown)

--- a/azafea/event_processors/ping/v1/cli.py
+++ b/azafea/event_processors/ping/v1/cli.py
@@ -25,7 +25,8 @@ log = logging.getLogger(__name__)
 
 def register_commands(subs: argparse._SubParsersAction) -> None:
     normalize_vendors = subs.add_parser('normalize-vendors',
-                                        help='Normalize the vendors in existing records')
+                                        help='Normalize the vendors in existing records',
+                                        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     normalize_vendors.add_argument('--chunk-size', type=int, default=5000,
                                    help='The size of the chunks to operate on')
     normalize_vendors.set_defaults(subcommand=do_normalize_vendors)

--- a/azafea/model.py
+++ b/azafea/model.py
@@ -68,7 +68,7 @@ class BaseModel:
         return '\n'.join(result)
 
 
-class ChunkedQuery(Query):
+class ChunkedQuery:
     def __init__(self, dbsession: 'DbSession', model: Type['Base'], chunk_size: int):
         self._query = dbsession.query(model).order_by(model.id)
         self._chunk_size = chunk_size


### PR DESCRIPTION
This fixes the definition of the `ChunkedQuery`, removing the unnecessary inheritance.

This also fixes the help output of the per-queue subcommands so they show the default values for options.