### PR TITLE
tests: Add a missing check

### DIFF
--- a/azafea/event_processors/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/metrics/tests/integration/test_metrics_cli.py
@@ -394,6 +394,7 @@ class TestMetrics(IntegrationTest):
         with self.db as dbsession:
             assert dbsession.query(Request).count() == 1
             assert dbsession.query(UnknownSingularEvent).count() == 5
+            assert dbsession.query(UnknownAggregateEvent).count() == 1
             assert dbsession.query(UnknownSequence).count() == 5
 
         # Replay the unknown events


### PR DESCRIPTION
I forgot this when I implemented replaying unknown aggregate events.