### PR TITLE
metrics: Make it faster to replay unknown events

### DIFF
--- a/azafea/event_processors/metrics/events/__init__.py
+++ b/azafea/event_processors/metrics/events/__init__.py
@@ -36,6 +36,9 @@ from ._base import (  # noqa: F401
     replay_unknown_aggregate_events,
     replay_unknown_sequences,
     replay_unknown_singular_events,
+    aggregate_event_is_known,
+    sequence_is_known,
+    singular_event_is_known,
 )
 
 

--- a/azafea/event_processors/metrics/events/_base.py
+++ b/azafea/event_processors/metrics/events/_base.py
@@ -493,6 +493,10 @@ def replay_invalid_sequences(invalid_events: Query) -> None:
         invalid_events.session.delete(invalid)
 
 
+def singular_event_is_known(event_id: str) -> bool:
+    return (event_id in SINGULAR_EVENT_MODELS) or (event_id in IGNORED_EVENTS)
+
+
 def replay_unknown_singular_events(unknown_events: Query) -> None:
     for unknown in unknown_events:
         event_id = str(unknown.event_id)
@@ -501,12 +505,7 @@ def replay_unknown_singular_events(unknown_events: Query) -> None:
             unknown_events.session.delete(unknown)
             continue
 
-        try:
-            event_model = SINGULAR_EVENT_MODELS[event_id]
-
-        except KeyError:
-            # This event UUID is still unknown, ignore it
-            continue
+        event_model = SINGULAR_EVENT_MODELS[event_id]
 
         # This event UUID was unknown but is now known, let's process it
         payload = GLib.Variant.new_from_bytes(GLib.VariantType('mv'),
@@ -538,6 +537,10 @@ def replay_unknown_singular_events(unknown_events: Query) -> None:
         unknown_events.session.delete(unknown)
 
 
+def aggregate_event_is_known(event_id: str) -> bool:
+    return (event_id in AGGREGATE_EVENT_MODELS) or (event_id in IGNORED_EVENTS)
+
+
 def replay_unknown_aggregate_events(unknown_events: Query) -> None:
     for unknown in unknown_events:
         event_id = str(unknown.event_id)
@@ -552,6 +555,10 @@ def replay_unknown_aggregate_events(unknown_events: Query) -> None:
         continue  # pragma: no cover
 
 
+def sequence_is_known(event_id: str) -> bool:
+    return (event_id in SEQUENCE_EVENT_MODELS) or (event_id in IGNORED_EVENTS)
+
+
 def replay_unknown_sequences(unknown_events: Query) -> None:
     for unknown in unknown_events:
         event_id = str(unknown.event_id)
@@ -560,12 +567,7 @@ def replay_unknown_sequences(unknown_events: Query) -> None:
             unknown_events.session.delete(unknown)
             continue
 
-        try:
-            event_model = SEQUENCE_EVENT_MODELS[event_id]
-
-        except KeyError:
-            # This event UUID is still unknown, ignore it
-            continue
+        event_model = SEQUENCE_EVENT_MODELS[event_id]
 
         # This event UUID was unknown but is now known, let's process it
 

--- a/azafea/event_processors/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/metrics/tests/integration/test_metrics_cli.py
@@ -299,7 +299,7 @@ class TestMetrics(IntegrationTest):
         # Create the table
         self.run_subcommand('initdb')
         self.ensure_tables(Request, ShellAppIsOpen, Uptime, InvalidSequence, InvalidSingularEvent,
-                           UnknownSequence, UnknownSingularEvent)
+                           UnknownAggregateEvent, UnknownSequence, UnknownSingularEvent)
 
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 

--- a/azafea/model.py
+++ b/azafea/model.py
@@ -101,6 +101,12 @@ class ChunkedQuery:
 
         return self
 
+    # FIXME: sqlalchemy-stubs doesn't have type hints for this
+    def filter(self, expression) -> 'ChunkedQuery':  # type: ignore
+        self._query = self._query.filter(expression)
+
+        return self
+
 
 class DbSession(SaSession):
     def chunked_query(self, model: Type['Base'], chunk_size: int = 5000) -> ChunkedQuery:


### PR DESCRIPTION
This brings 2 improvements so that the commands aren't so long:

1. there is no point going over all the unknown events we already know will still be unknown after the replay, so those "unknown unknowns" are entirely skipped, resulting in a huge speed bump in some cases;

2. the admin running the command can now specify a `--no-more-than` option, so that in the event that there are still too many "known unknowns" to go through, they can do it piecemeal, instead of staring at the progress bar for hours.