### PR TITLE
Enable row-level security

### DIFF
--- a/azafea/event_processors/metrics/v2/migrations/27156a7be72d_enable_row_level_security.py
+++ b/azafea/event_processors/metrics/v2/migrations/27156a7be72d_enable_row_level_security.py
@@ -1,0 +1,25 @@
+# type: ignore
+
+"""Enable row-level security
+
+Revision ID: 27156a7be72d
+Revises: 7f4c0154d6cd
+Create Date: 2019-12-23 10:29:06.431725
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '27156a7be72d'
+down_revision = '7f4c0154d6cd'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('ALTER TABLE metrics_request_v2 ENABLE ROW LEVEL SECURITY')
+
+
+def downgrade():
+    op.execute('ALTER TABLE metrics_request_v2 DISABLE ROW LEVEL SECURITY')


### PR DESCRIPTION
This will allow setting things up on the PostgreSQL side so that most
accounts can only view the user data for the deployments they are
responsible for.

For example, the people at Endless Solutions with access to the database
will only see data for Solutions machines, not for all other users.

The actual security policies will be created and maintained in the
deployment configuration in Terraform, because the azafea user (owning
the database) doesn't have the permissions to do those.