### PR TITLE
Embrace containers for the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ branches:
   only:
   - master
 
-python:
-- "3.7"
-
 services:
+- docker
 - redis-server
 
 before_install:
@@ -16,13 +14,10 @@ before_install:
 
 # Use PostgreSQL 11
 - sudo apt --yes --quiet autoremove --purge postgresql-{,client-,contrib-}{9,10}\*
-- sudo apt --yes --quiet install postgresql-11 postgresql-client-11
-
-# Install the pygobject build deps
-- sudo apt --yes --quiet install gobject-introspection libcairo2-dev libffi-dev libgirepository1.0-dev libglib2.0-dev
+- sudo apt --yes --quiet install postgresql-11
 
 install:
-- pipenv install --deploy --dev
+- docker build --build-arg build_type=dev --tag azafea-tests .
 
 before_script:
 # Create the PostgreSQL role and database
@@ -37,7 +32,7 @@ matrix:
   include:
   - name: "Integration Tests"
     script:
-    - pipenv run test-all
+    - docker run --rm --network=host --entrypoint="" azafea-tests pipenv run test-all
   - name: "Lint and Type Checking"
     script:
-    - pipenv run lint
+    - docker run --rm --network=host --entrypoint="" azafea-tests pipenv run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 - sudo apt --yes --quiet update
 
 # Use PostgreSQL 11
-- sudo apt --yes --quiet autoremove --purge postgresql-{,client-,contrib-}{9,10}\*
+- sudo apt --yes --quiet autoremove --purge libpq\* postgresql-{,client-,contrib-}{9,10}\*
 - sudo apt --yes --quiet install postgresql-11
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
-language: python
 sudo: required
+language: minimal
+addons:
+  apt:
+    sources:
+    - sourceline: "ppa:chris-lea/redis-server"
+    packages:
+    - redis-server
+    - redis-tools
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 sudo: required
 language: minimal
 addons:


### PR DESCRIPTION
Now that we can have Docker images for development, this also moves the CI to use it instead of whatever Travis does to their poor old Ubuntu 16.04.

Controlling our test environment with containers frees us from the underlying host, so we can use a more minimal Travis host image and upgrade to a newer Ubuntu for the host.

Finally, this fixes a minor problem with our CI where some parts of an undesired PostgreSQL version would remain installed. While that never caused any problem, removing it avoids all potential for any such problems in the future.