### PR TITLE
config: Allow passing PostgreSQL connection arguments

### DIFF
--- a/azafea/cli/commands.py
+++ b/azafea/cli/commands.py
@@ -61,8 +61,7 @@ def do_dropdb(config: Config, args: argparse.Namespace) -> None:
         log.error('Could not clear the database: no event queue configured')
         raise NoEventQueueExit()
 
-    db = Db(config.postgresql.host, config.postgresql.port, config.postgresql.user,
-            config.postgresql.password, config.postgresql.database)
+    db = Db(config.postgresql)
     db.drop_all()
 
 
@@ -71,8 +70,7 @@ def do_initdb(config: Config, args: argparse.Namespace) -> None:
         log.error('Could not initialize the database: no event queue configured')
         raise NoEventQueueExit()
 
-    db = Db(config.postgresql.host, config.postgresql.port, config.postgresql.user,
-            config.postgresql.password, config.postgresql.database)
+    db = Db(config.postgresql)
     db.create_all()
 
 
@@ -95,8 +93,7 @@ def do_make_migration(config: Config, args: argparse.Namespace) -> None:
         log.info("Configured queue handlers don't have 'migrations' directories")
         return None
 
-    db = Db(config.postgresql.host, config.postgresql.port, config.postgresql.user,
-            config.postgresql.password, config.postgresql.database)
+    db = Db(config.postgresql)
 
     with db as dbsession:
         alembic_config.attributes['connection'] = dbsession.connection()
@@ -129,8 +126,7 @@ def do_migratedb(config: Config, args: argparse.Namespace) -> None:
         log.info("Configured queue handlers don't have migrations")
         return None
 
-    db = Db(config.postgresql.host, config.postgresql.port, config.postgresql.user,
-            config.postgresql.password, config.postgresql.database)
+    db = Db(config.postgresql)
 
     with db as dbsession:
         alembic_config.attributes['connection'] = dbsession.connection()

--- a/azafea/config/__init__.py
+++ b/azafea/config/__init__.py
@@ -130,6 +130,7 @@ class PostgreSQL(_Base):
     user: str = 'azafea'
     password: str = DEFAULT_PASSWORD
     database: str = 'azafea'
+    connect_args: Dict[str, str] = dataclasses.field(default_factory=dict)
 
     @validator('host', pre=True)
     def host_is_non_empty_string(cls, value: Any) -> str:

--- a/azafea/event_processors/activation/v1/cli.py
+++ b/azafea/event_processors/activation/v1/cli.py
@@ -43,9 +43,7 @@ def _normalize_chunk(chunk: Query) -> None:
 
 
 def do_normalize_vendors(config: Config, args: argparse.Namespace) -> None:
-    db = Db(config.postgresql.host, config.postgresql.port, config.postgresql.user,
-            config.postgresql.password, config.postgresql.database)
-
+    db = Db(config.postgresql)
     log.info('Normalizing the vendors for activations')
 
     with db as dbsession:

--- a/azafea/event_processors/metrics/v2/cli.py
+++ b/azafea/event_processors/metrics/v2/cli.py
@@ -72,9 +72,7 @@ def _normalize_chunk(chunk: Query) -> None:
 
 
 def do_normalize_vendors(config: Config, args: argparse.Namespace) -> None:
-    db = Db(config.postgresql.host, config.postgresql.port, config.postgresql.user,
-            config.postgresql.password, config.postgresql.database)
-
+    db = Db(config.postgresql)
     log.info('Normalizing the vendors for "updater branch selected" (%s) events',
              UpdaterBranchSelected.__event_uuid__)
 
@@ -97,9 +95,7 @@ def do_normalize_vendors(config: Config, args: argparse.Namespace) -> None:
 
 
 def do_replay_invalid(config: Config, args: argparse.Namespace) -> None:
-    db = Db(config.postgresql.host, config.postgresql.port, config.postgresql.user,
-            config.postgresql.password, config.postgresql.database)
-
+    db = Db(config.postgresql)
     log.info('Replaying the invalid singular events…')
 
     with db as dbsession:
@@ -145,9 +141,7 @@ def do_replay_invalid(config: Config, args: argparse.Namespace) -> None:
 
 
 def do_replay_unknown(config: Config, args: argparse.Namespace) -> None:
-    db = Db(config.postgresql.host, config.postgresql.port, config.postgresql.user,
-            config.postgresql.password, config.postgresql.database)
-
+    db = Db(config.postgresql)
     log.info('Replaying the unknown singular events…')
 
     with db as dbsession:

--- a/azafea/event_processors/ping/v1/cli.py
+++ b/azafea/event_processors/ping/v1/cli.py
@@ -65,9 +65,7 @@ def _normalize_chunk(chunk: Query) -> None:
 
 
 def do_normalize_vendors(config: Config, args: argparse.Namespace) -> None:
-    db = Db(config.postgresql.host, config.postgresql.port, config.postgresql.user,
-            config.postgresql.password, config.postgresql.database)
-
+    db = Db(config.postgresql)
     log.info('Normalizing the vendors for ping configurations')
 
     with db as dbsession:

--- a/azafea/model.py
+++ b/azafea/model.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm.session import Session as SaSession, sessionmaker
 from sqlalchemy.schema import Column, CreateColumn, MetaData
 from sqlalchemy.types import Enum, TypeDecorator
 
+from .config import PostgreSQL as PgConfig
 from .utils import get_fqdn
 
 
@@ -115,9 +116,10 @@ class DbSession(SaSession):
 
 
 class Db:
-    def __init__(self, host: str, port: int, user: str, password: str, db: str) -> None:
-        self._url = URL('postgresql+psycopg2', username=user, host=host, port=port, database=db)
-        self._engine = create_engine(self._url, connect_args={'password': password})
+    def __init__(self, pgconfig: PgConfig) -> None:
+        self._url = URL('postgresql+psycopg2', username=pgconfig.user, host=pgconfig.host,
+                        port=pgconfig.port, database=pgconfig.database)
+        self._engine = create_engine(self._url, connect_args={'password': pgconfig.password})
         self._session_factory = sessionmaker(bind=self._engine, class_=DbSession)
 
         # Try to connect, to fail early if the PostgreSQL server can't be reached.

--- a/azafea/model.py
+++ b/azafea/model.py
@@ -7,6 +7,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
+import copy
 from operator import attrgetter
 from types import TracebackType
 from typing import Any, Iterator, Optional, Type
@@ -117,9 +118,12 @@ class DbSession(SaSession):
 
 class Db:
     def __init__(self, pgconfig: PgConfig) -> None:
+        connect_args = copy.deepcopy(pgconfig.connect_args)
+        connect_args['password'] = pgconfig.password
+
         self._url = URL('postgresql+psycopg2', username=pgconfig.user, host=pgconfig.host,
                         port=pgconfig.port, database=pgconfig.database)
-        self._engine = create_engine(self._url, connect_args={'password': pgconfig.password})
+        self._engine = create_engine(self._url, connect_args=connect_args)
         self._session_factory = sessionmaker(bind=self._engine, class_=DbSession)
 
         # Try to connect, to fail early if the PostgreSQL server can't be reached.

--- a/azafea/model.py
+++ b/azafea/model.py
@@ -115,11 +115,11 @@ class DbSession(SaSession):
 
 class Db:
     def __init__(self, host: str, port: int, user: str, password: str, db: str) -> None:
-        self._engine = create_engine(f'postgresql+psycopg2://{user}:{password}@{host}:{port}/{db}')
-        self._session_factory = sessionmaker(bind=self._engine, class_=DbSession)
-
         # Store the URL to use in exceptions
         self._url = f'postgresql://{user}@{host}:{port}/{db}'
+
+        self._engine = create_engine(f'postgresql+psycopg2://{user}:{password}@{host}:{port}/{db}')
+        self._session_factory = sessionmaker(bind=self._engine, class_=DbSession)
 
         # Try to connect, to fail early if the PostgreSQL server can't be reached.
         self._ensure_connection()

--- a/azafea/model.py
+++ b/azafea/model.py
@@ -13,6 +13,7 @@ from typing import Any, Iterator, Optional, Type
 
 from sqlalchemy.dialects.postgresql.base import PGDDLCompiler
 from sqlalchemy.engine import create_engine
+from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.declarative import declarative_base
@@ -115,10 +116,8 @@ class DbSession(SaSession):
 
 class Db:
     def __init__(self, host: str, port: int, user: str, password: str, db: str) -> None:
-        # Store the URL to use in exceptions
-        self._url = f'postgresql://{user}@{host}:{port}/{db}'
-
-        self._engine = create_engine(f'postgresql+psycopg2://{user}:{password}@{host}:{port}/{db}')
+        self._url = URL('postgresql+psycopg2', username=user, host=host, port=port, database=db)
+        self._engine = create_engine(self._url, connect_args={'password': password})
         self._session_factory = sessionmaker(bind=self._engine, class_=DbSession)
 
         # Try to connect, to fail early if the PostgreSQL server can't be reached.

--- a/azafea/processor.py
+++ b/azafea/processor.py
@@ -38,11 +38,7 @@ class Processor(Process):
         self._continue = False
 
     def _get_postgresql(self) -> Db:
-        db = Db(self.config.postgresql.host, self.config.postgresql.port,
-                self.config.postgresql.user, self.config.postgresql.password,
-                self.config.postgresql.database)
-
-        return db
+        return Db(self.config.postgresql)
 
     def _get_redis(self) -> Redis:
         redis = Redis(host=self.config.redis.host, port=self.config.redis.port,

--- a/azafea/tests/integration/__init__.py
+++ b/azafea/tests/integration/__init__.py
@@ -88,10 +88,7 @@ class IntegrationTest:
         self.config_file = config_file
         self.config = Config.from_file(self.config_file)
 
-        self.db = Db(self.config.postgresql.host, self.config.postgresql.port,
-                     self.config.postgresql.user, self.config.postgresql.password,
-                     self.config.postgresql.database)
-
+        self.db = Db(self.config.postgresql)
         self.redis = Redis(host=self.config.redis.host, port=self.config.redis.port,
                            password=self.config.redis.password)
 

--- a/azafea/tests/test_cli.py
+++ b/azafea/tests/test_cli.py
@@ -248,6 +248,8 @@ def test_print_config(capfd, monkeypatch, make_config_file):
         'password = "** hidden **"',
         'database = "azafea"',
         '',
+        '[postgresql.connect_args]',
+        '',
         '[queues.some-queue]',
         'handler = "azafea.tests.test_cli"',
         '------ END ------',

--- a/azafea/tests/test_cli.py
+++ b/azafea/tests/test_cli.py
@@ -575,8 +575,8 @@ def test_run_postgresql_connection_error(capfd, monkeypatch, make_config_file):
             azafea.cli.run_command('-c', str(config_file), 'run')
 
     capture = capfd.readouterr()
-    assert ('Could not connect to PostgreSQL: '
-            'connection refused on postgresql://azafea@no-such-host:1/azafea') in capture.err
+    assert ('Could not connect to PostgreSQL: connection refused on '
+            'postgresql+psycopg2://azafea@no-such-host:1/azafea') in capture.err
 
 
 def test_per_queue_command(capfd, monkeypatch, make_config_file):

--- a/azafea/tests/test_config.py
+++ b/azafea/tests/test_config.py
@@ -47,6 +47,8 @@ def test_defaults():
         'database = "azafea"',
         '',
         '[queues]',
+        '',
+        '[postgresql.connect_args]',
     ])
 
 
@@ -71,7 +73,10 @@ def test_override(monkeypatch, make_config):
         config = make_config({
             'main': {'number_of_workers': 1},
             'redis': {'port': 42},
-            'postgresql': {'host': 'pg-server'},
+            'postgresql': {
+                'host': 'pg-server',
+                'connect_args': {'sslmode': 'require', 'connect_timeout': 3},
+            },
             'queues': {'some-queue': {'handler': 'azafea.tests.test_config'}},
         })
 
@@ -84,6 +89,7 @@ def test_override(monkeypatch, make_config):
     assert config.postgresql.user == 'azafea'
     assert config.postgresql.password == 'CHANGE ME!!'
     assert config.postgresql.database == 'azafea'
+    assert config.postgresql.connect_args == {'sslmode': 'require', 'connect_timeout': '3'}
 
     assert str(config) == '\n'.join([
         '[main]',
@@ -102,6 +108,10 @@ def test_override(monkeypatch, make_config):
         'user = "azafea"',
         'password = "** hidden **"',
         'database = "azafea"',
+        '',
+        '[postgresql.connect_args]',
+        'sslmode = "require"',
+        'connect_timeout = "3"',
         '',
         '[queues.some-queue]',
         'handler = "azafea.tests.test_config"',

--- a/azafea/tests/test_model.py
+++ b/azafea/tests/test_model.py
@@ -22,9 +22,7 @@ def test_use_db_session(monkeypatch, mock_sessionmaker):
 
     with monkeypatch.context() as m:
         m.setattr(azafea.model, 'sessionmaker', mock_sessionmaker)
-        db = azafea.model.Db(config.postgresql.host, config.postgresql.port,
-                             config.postgresql.user, config.postgresql.password,
-                             config.postgresql.database)
+        db = azafea.model.Db(config.postgresql)
 
         with db as dbsession:
             assert dbsession.open
@@ -44,9 +42,7 @@ def test_fail_committing_db_session(monkeypatch, mock_sessionmaker):
 
     with monkeypatch.context() as m:
         m.setattr(azafea.model, 'sessionmaker', mock_sessionmaker)
-        db = azafea.model.Db(config.postgresql.host, config.postgresql.port,
-                             config.postgresql.user, config.postgresql.password,
-                             config.postgresql.database)
+        db = azafea.model.Db(config.postgresql)
 
         with pytest.raises(ValueError) as exc_info:
             with db as dbsession:
@@ -64,9 +60,7 @@ def test_exit_from_already_rolled_back_session(monkeypatch, mock_sessionmaker):
 
     with monkeypatch.context() as m:
         m.setattr(azafea.model, 'sessionmaker', mock_sessionmaker)
-        db = azafea.model.Db(config.postgresql.host, config.postgresql.port,
-                             config.postgresql.user, config.postgresql.password,
-                             config.postgresql.database)
+        db = azafea.model.Db(config.postgresql)
 
         with db as dbsession:
             assert dbsession.open
@@ -88,9 +82,7 @@ def test_fail_in_db_session(monkeypatch, mock_sessionmaker):
 
     with monkeypatch.context() as m:
         m.setattr(azafea.model, 'sessionmaker', mock_sessionmaker)
-        db = azafea.model.Db(config.postgresql.host, config.postgresql.port,
-                             config.postgresql.user, config.postgresql.password,
-                             config.postgresql.database)
+        db = azafea.model.Db(config.postgresql)
 
         with pytest.raises(ValueError) as exc_info:
             with db as dbsession:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -34,6 +34,8 @@ the default options:
    password = "CHANGE ME!!"
    database = "azafea"
 
+   [postgresql.connect_args]
+
    [queues]
 
 
@@ -118,6 +120,26 @@ stores its data.
   The database in which Azafea will store its processed events.
 
   The default is ``"azafea"``
+
+
+The ``postgresql.connect_args`` table
+-------------------------------------
+
+This can be passed arbitrary keys and values, corresponding to libpq connection
+parameters.
+
+Refer to
+`the PostgreSQL documentation <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS>`_
+for more details.
+
+An example would be:
+
+.. code-block:: toml
+
+   [postgresql.connect_args]
+   connect_timeout = 3
+   sslmode = "require"
+
 
 .. _queue-config:
 


### PR DESCRIPTION
PostgreSQL's libpq supports many connection arguments:

https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS

SQLAlchemy makes it easy to pass them down to PsycoPG2 and libpq:

https://docs.sqlalchemy.org/en/13/core/engines.html#custom-dbapi-args

This commit introduces a new "connect_args" configuration table, nested
under the "postgresql" one.

It can be passed arbitrary key/values, like "sslmode" or
"connect_timeout" for example.

Fixes #74