### PR TITLE
metrics: Drop the serialized request column

### DIFF
--- a/azafea/event_processors/endless/metrics/request.py
+++ b/azafea/event_processors/endless/metrics/request.py
@@ -12,7 +12,7 @@ from hashlib import sha512
 from typing import Generator
 
 from sqlalchemy.schema import Column, Index
-from sqlalchemy.types import BigInteger, Date, DateTime, Integer, LargeBinary, Unicode
+from sqlalchemy.types import BigInteger, Date, DateTime, Integer, Unicode
 
 from azafea.model import Base, DbSession, View
 
@@ -25,7 +25,6 @@ class Request(Base):
     __tablename__ = 'metrics_request_v2'
 
     id = Column(Integer, primary_key=True)
-    serialized = Column(LargeBinary)
     sha512 = Column(Unicode, nullable=False, unique=True)
     received_at = Column(DateTime(timezone=True), nullable=False)
     absolute_timestamp = Column(BigInteger, nullable=False)
@@ -107,6 +106,6 @@ class RequestBuilder:
         return get_child_values(self._variant.get_child_value(6))
 
     def build_request(self) -> Request:
-        return Request(serialized=self._serialized, sha512=self.sha512, machine_id=self.machine_id,
+        return Request(sha512=self.sha512, machine_id=self.machine_id,
                        received_at=self._received_at, absolute_timestamp=self.absolute_timestamp,
                        relative_timestamp=self.relative_timestamp, send_number=self.send_number)

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
@@ -47,13 +47,13 @@ class TestMetrics(IntegrationTest):
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-1', received_at=occured_at,
+            dbsession.add(Request(sha512='sha512-1', received_at=occured_at,
                                   absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
                                   send_number=0))
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-2', received_at=occured_at,
+            dbsession.add(Request(sha512='sha512-2', received_at=occured_at,
                                   absolute_timestamp=3, relative_timestamp=4, machine_id='machine2',
                                   send_number=0))
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-3', received_at=occured_at,
+            dbsession.add(Request(sha512='sha512-3', received_at=occured_at,
                                   absolute_timestamp=5, relative_timestamp=6, machine_id='machine3',
                                   send_number=0))
 
@@ -114,13 +114,13 @@ class TestMetrics(IntegrationTest):
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
 
         with self.db as dbsession:
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-1', received_at=occured_at,
+            dbsession.add(Request(sha512='sha512-1', received_at=occured_at,
                                   absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
                                   send_number=0))
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-2', received_at=occured_at,
+            dbsession.add(Request(sha512='sha512-2', received_at=occured_at,
                                   absolute_timestamp=3, relative_timestamp=4, machine_id='machine2',
                                   send_number=0))
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-3', received_at=occured_at,
+            dbsession.add(Request(sha512='sha512-3', received_at=occured_at,
                                   absolute_timestamp=5, relative_timestamp=6, machine_id='machine3',
                                   send_number=0))
 
@@ -180,13 +180,13 @@ class TestMetrics(IntegrationTest):
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-1', received_at=occured_at,
+            dbsession.add(Request(sha512='sha512-1', received_at=occured_at,
                                   absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
                                   send_number=0))
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-2', received_at=occured_at,
+            dbsession.add(Request(sha512='sha512-2', received_at=occured_at,
                                   absolute_timestamp=3, relative_timestamp=4, machine_id='machine2',
                                   send_number=0))
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-3', received_at=occured_at,
+            dbsession.add(Request(sha512='sha512-3', received_at=occured_at,
                                   absolute_timestamp=5, relative_timestamp=6, machine_id='machine3',
                                   send_number=0))
 
@@ -254,7 +254,7 @@ class TestMetrics(IntegrationTest):
         )))
 
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='whatever',
                               send_number=0)
             dbsession.add(request)
@@ -299,7 +299,7 @@ class TestMetrics(IntegrationTest):
         )))
 
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='whatever',
                               send_number=0)
             dbsession.add(request)
@@ -328,19 +328,19 @@ class TestMetrics(IntegrationTest):
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
                               send_number=0)
             dbsession.add(request)
 
-            request = Request(serialized=b'whatever2', sha512='whatever2', received_at=occured_at,
+            request = Request(sha512='whatever2', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
                               send_number=0)
             dbsession.add(request)
             dbsession.add(DualBootBooted(request=request, user_id=1001, occured_at=occured_at,
                                          payload=GLib.Variant('mv', None)))
 
-            request = Request(serialized=b'whatever3', sha512='whatever3', received_at=occured_at,
+            request = Request(sha512='whatever3', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine3',
                               send_number=0)
             dbsession.add(request)
@@ -360,7 +360,7 @@ class TestMetrics(IntegrationTest):
         # The machine2 has sent a new event after creating the Machine model, but before running
         # the replay command
         with self.db as dbsession:
-            request = Request(serialized=b'whatever4', sha512='whatever4', received_at=occured_at,
+            request = Request(sha512='whatever4', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
                               send_number=0)
             dbsession.add(request)
@@ -403,7 +403,7 @@ class TestMetrics(IntegrationTest):
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
                               send_number=0)
             dbsession.add(request)
@@ -412,7 +412,7 @@ class TestMetrics(IntegrationTest):
             dbsession.add(ImageVersion(request=request, user_id=1001, occured_at=occured_at,
                                        payload=GLib.Variant('mv', GLib.Variant('s', image_id_1))))
 
-            request = Request(serialized=b'whatever2', sha512='whatever2', received_at=occured_at,
+            request = Request(sha512='whatever2', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
                               send_number=0)
             dbsession.add(request)
@@ -434,7 +434,7 @@ class TestMetrics(IntegrationTest):
         # The machine1 has sent a new event after creating the Machine model, but before running
         # the replay command
         with self.db as dbsession:
-            request = Request(serialized=b'whatever3', sha512='whatever3', received_at=occured_at,
+            request = Request(sha512='whatever3', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
                               send_number=0)
             dbsession.add(request)
@@ -477,19 +477,19 @@ class TestMetrics(IntegrationTest):
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
                               send_number=0)
             dbsession.add(request)
 
-            request = Request(serialized=b'whatever2', sha512='whatever2', received_at=occured_at,
+            request = Request(sha512='whatever2', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
                               send_number=0)
             dbsession.add(request)
             dbsession.add(LiveUsbBooted(request=request, user_id=1001, occured_at=occured_at,
                                         payload=GLib.Variant('mv', None)))
 
-            request = Request(serialized=b'whatever3', sha512='whatever3', received_at=occured_at,
+            request = Request(sha512='whatever3', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine3',
                               send_number=0)
             dbsession.add(request)
@@ -509,7 +509,7 @@ class TestMetrics(IntegrationTest):
         # The machine2 has sent a new event after creating the Machine model, but before running
         # the replay command
         with self.db as dbsession:
-            request = Request(serialized=b'whatever4', sha512='whatever4', received_at=occured_at,
+            request = Request(sha512='whatever4', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
                               send_number=0)
             dbsession.add(request)
@@ -555,7 +555,7 @@ class TestMetrics(IntegrationTest):
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='whatever',
                               send_number=0)
             dbsession.add(request)
@@ -727,7 +727,7 @@ class TestMetrics(IntegrationTest):
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='whatever',
                               send_number=0)
             dbsession.add(request)
@@ -1072,7 +1072,7 @@ class TestMetrics(IntegrationTest):
         payload = GLib.Variant('mv', GLib.Variant('a{ss}', info))
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='whatever',
                               send_number=0)
             dbsession.add(request)
@@ -1110,7 +1110,7 @@ class TestMetrics(IntegrationTest):
         payload = GLib.Variant('mv', GLib.Variant('a{ss}', info))
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='whatever',
                               send_number=0)
             dbsession.add(request)
@@ -1139,17 +1139,13 @@ class TestMetrics(IntegrationTest):
         occured_at_2 = occured_at_1 + timedelta(days=1)
 
         with self.db as dbsession:
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-1',
-                                  received_at=occured_at_1, absolute_timestamp=1,
+            dbsession.add(Request(sha512='sha512-1', received_at=occured_at_1, absolute_timestamp=1,
                                   relative_timestamp=2, machine_id='machine1', send_number=0))
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-2',
-                                  received_at=occured_at_1, absolute_timestamp=3,
+            dbsession.add(Request(sha512='sha512-2', received_at=occured_at_1, absolute_timestamp=3,
                                   relative_timestamp=4, machine_id='machine2', send_number=0))
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-3',
-                                  received_at=occured_at_1, absolute_timestamp=5,
+            dbsession.add(Request(sha512='sha512-3', received_at=occured_at_1, absolute_timestamp=5,
                                   relative_timestamp=6, machine_id='machine2', send_number=0))
-            dbsession.add(Request(serialized=b'whatever', sha512='sha512-4',
-                                  received_at=occured_at_2, absolute_timestamp=7,
+            dbsession.add(Request(sha512='sha512-4', received_at=occured_at_2, absolute_timestamp=7,
                                   relative_timestamp=8, machine_id='machine2', send_number=0))
 
         with self.db as dbsession:

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_db_functions.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_db_functions.py
@@ -46,9 +46,8 @@ class TestMetrics(IntegrationTest):
 
         # Add a request with an image version
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
-                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine',
-                              send_number=0)
+            request = Request(sha512='whatever', received_at=occured_at, absolute_timestamp=1,
+                              relative_timestamp=2, machine_id='machine', send_number=0)
             dbsession.add(request)
 
             dbsession.add(ImageVersion(request=request, user_id=1001, occured_at=occured_at,
@@ -73,9 +72,8 @@ class TestMetrics(IntegrationTest):
 
         # Add a request without an image version
         with self.db as dbsession:
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
-                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine',
-                              send_number=0)
+            request = Request(sha512='whatever', received_at=occured_at, absolute_timestamp=1,
+                              relative_timestamp=2, machine_id='machine', send_number=0)
             dbsession.add(request)
 
         # Ensure this machine has no product/personality

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -1990,7 +1990,7 @@ class TestMetrics(IntegrationTest):
 
         with self.db as dbsession:
             # Add a first request with 1 dualboot, 2 image version and 3 live usb events
-            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+            request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
                               send_number=0)
             dbsession.add(request)
@@ -2010,7 +2010,7 @@ class TestMetrics(IntegrationTest):
                                         payload=GLib.Variant('mv', None)))
 
             # Add a second request with 1 dualboot, 2 image version and 3 live usb events
-            request = Request(serialized=b'whatever2', sha512='whatever2', received_at=occured_at,
+            request = Request(sha512='whatever2', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
                               send_number=0)
             dbsession.add(request)

--- a/azafea/event_processors/endless/metrics/v2/migrations/8eb67a73775b_remove_the_serialized_request_column.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/8eb67a73775b_remove_the_serialized_request_column.py
@@ -1,0 +1,27 @@
+# type: ignore
+
+"""Remove the serialized request column
+
+Revision ID: 8eb67a73775b
+Revises: 63365dc8695a
+Create Date: 2020-01-07 14:12:24.190678
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '8eb67a73775b'
+down_revision = '63365dc8695a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('metrics_request_v2', 'serialized')
+
+
+def downgrade():
+    op.add_column('metrics_request_v2', sa.Column('serialized', postgresql.BYTEA(),
+                                                  autoincrement=False, nullable=True))


### PR DESCRIPTION
I had decided to keep that originally so that in case of a dramatic
failure we would be able to reparse everything from the raw bytes to fix
whatever issue had come up.

It seems like things are working just fine though, so the time has come
to remove it and reclaim some disk space.

https://phabricator.endlessm.com/T31411