### PR TITLE
utils: Always flush the progress bar

### DIFF
--- a/azafea/utils.py
+++ b/azafea/utils.py
@@ -45,4 +45,4 @@ def progress(current: int, total: int, end: str = '') -> None:
 
     remaining = bar_length - done
 
-    print(f'\r|{"#" * done}{" " * remaining}|  {current} / {total}', end=end)
+    print(f'\r|{"#" * done}{" " * remaining}|  {current} / {total}', end=end, flush=True)


### PR DESCRIPTION
This should avoid getting all the progress output at the end in the
CloudWatch logs.