### PR TITLE
metrics: Fix the image product/personality functions

### DIFF
--- a/azafea/event_processors/metrics/v2/migrations/f7b3720152d2_explicitly_specify_the_public_.py
+++ b/azafea/event_processors/metrics/v2/migrations/f7b3720152d2_explicitly_specify_the_public_.py
@@ -1,0 +1,82 @@
+# type: ignore
+
+"""Explicitly specify the public tablespace for functions, and declare them parallel-safe
+
+Revision ID: f7b3720152d2
+Revises: 7f4c0154d6cd
+Create Date: 2020-01-21 12:56:28.341377
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f7b3720152d2'
+down_revision = '7f4c0154d6cd'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index('ix_metrics_request_v2_image_personality')
+    op.execute('CREATE OR REPLACE FUNCTION get_image_personality(_machine_id text) RETURNS text\n'
+               '  LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE\n'
+               '  AS $$\n'
+               '    BEGIN\n'
+               '      RETURN (\n'
+               "        SELECT reverse(split_part(reverse(image_id), '.', 1)) AS personality\n"
+               '          FROM public.metrics_machine\n'
+               '          WHERE metrics_machine.machine_id = _machine_id\n'
+               '      ) ;\n'
+               '    END;\n'
+               '  $$;')
+    op.create_index(op.f('ix_metrics_request_v2_image_personality'), 'metrics_request_v2',
+                    [sa.text('get_image_personality(machine_id)')], unique=False)
+
+    op.drop_index('ix_metrics_request_v2_image_product')
+    op.execute('CREATE OR REPLACE FUNCTION get_image_product(_machine_id text) RETURNS text\n'
+               '  LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE\n'
+               '  AS $$\n'
+               '    BEGIN\n'
+               '      RETURN (\n'
+               "        SELECT split_part(image_id, '-', 1) AS product\n"
+               '          FROM public.metrics_machine\n'
+               '          WHERE metrics_machine.machine_id = _machine_id\n'
+               '      ) ;\n'
+               '    END;\n'
+               '  $$;')
+    op.create_index(op.f('ix_metrics_request_v2_image_product'), 'metrics_request_v2',
+                    [sa.text('get_image_product(machine_id)')], unique=False)
+
+
+def downgrade():
+    op.drop_index('ix_metrics_request_v2_image_personality')
+    op.execute('CREATE OR REPLACE FUNCTION get_image_personality(_machine_id text) RETURNS text\n'
+               '  LANGUAGE plpgsql IMMUTABLE\n'
+               '  AS $$\n'
+               '    BEGIN\n'
+               '      RETURN (\n'
+               "        SELECT reverse(split_part(reverse(image_id), '.', 1)) AS personality\n"
+               '          FROM metrics_machine\n'
+               '          WHERE metrics_machine.machine_id = _machine_id\n'
+               '      ) ;\n'
+               '    END;\n'
+               '  $$;')
+    op.create_index(op.f('ix_metrics_request_v2_image_personality'), 'metrics_request_v2',
+                    [sa.text('get_image_personality(machine_id)')], unique=False)
+
+    op.drop_index('ix_metrics_request_v2_image_product')
+    op.execute('CREATE OR REPLACE FUNCTION get_image_product(_machine_id text) RETURNS text\n'
+               '  LANGUAGE plpgsql IMMUTABLE\n'
+               '  AS $$\n'
+               '    BEGIN\n'
+               '      RETURN (\n'
+               "        SELECT split_part(image_id, '-', 1) AS product\n"
+               '          FROM metrics_machine\n'
+               '          WHERE metrics_machine.machine_id = _machine_id\n'
+               '      ) ;\n'
+               '    END;\n'
+               '  $$;')
+    op.create_index(op.f('ix_metrics_request_v2_image_product'), 'metrics_request_v2',
+                    [sa.text('get_image_product(machine_id)')], unique=False)


### PR DESCRIPTION
The PostgreSQL autovacuum workers keep failing their ANALYZE step in
production:

```
  2020-01-21 11:56:53 UTC::@:[22993]:ERROR:  relation "metrics_machine" does not exist at character 102
  2020-01-21 11:56:53 UTC::@:[22993]:QUERY:  SELECT (
                  SELECT reverse(split_part(reverse(image_id), '.', 1)) AS personality
                    FROM metrics_machine
                    WHERE metrics_machine.machine_id = _machine_id
                )
  2020-01-21 11:56:53 UTC::@:[22993]:CONTEXT:  PL/pgSQL function public.get_image_personality(text) line 3 at RETURN
          automatic analyze of table "azafea.public.metrics_request_v2"
```

This is because they operate in a different context where they
apparently don't assume the "public" tablespace to be the default.

This migration recreates the functions (recreating the corresponding
indexes) to fix that, by explicitly specifying that the tables belong to
the public tablespace.

This migration also declares the functions as parallel safe, since they are
and this can help the PostgreSQL query optimizer.