### PR TITLE
utils: Add a newline to the progress bar when not in a TTY

### DIFF
--- a/azafea/tests/test_utils.py
+++ b/azafea/tests/test_utils.py
@@ -61,17 +61,20 @@ def test_progress(capfd):
     azafea.utils.progress(0, 6)
 
     capture = capfd.readouterr()
-    assert capture.out == '\r|                                                            |  0 / 6'
+    assert capture.out == (
+        '\r|                                                            |  0 / 6\n')
 
     azafea.utils.progress(2, 6)
 
     capture = capfd.readouterr()
-    assert capture.out == '\r|####################                                        |  2 / 6'
+    assert capture.out == (
+        '\r|####################                                        |  2 / 6\n')
 
     azafea.utils.progress(4, 6)
 
     capture = capfd.readouterr()
-    assert capture.out == '\r|########################################                    |  4 / 6'
+    assert capture.out == (
+        '\r|########################################                    |  4 / 6\n')
 
     azafea.utils.progress(6, 6, end='\n')
 

--- a/azafea/utils.py
+++ b/azafea/utils.py
@@ -9,6 +9,7 @@
 
 from importlib import import_module
 import os
+import sys
 from typing import Callable
 
 
@@ -33,6 +34,9 @@ def get_callable(module_name: str, callable_name: str) -> Callable:
 
 def progress(current: int, total: int, end: str = '') -> None:
     bar_length = 60
+
+    if not end.endswith('\n') and not sys.stdout.isatty():
+        end += '\n'
 
     if current > total:
         current = total


### PR DESCRIPTION
Simply flushing each progress output wasn't enough to get them to appear
instantly in the CloudWatch logs, which still seems to buffer them.

This should hopefully solve the problem, and is nicer anyway when
redirecting the command output.