### PR TITLE
metrics: Add hack news quest link event

### DIFF
--- a/azafea/event_processors/metrics/events/__init__.py
+++ b/azafea/event_processors/metrics/events/__init__.py
@@ -255,6 +255,22 @@ class HackClubhouseMode(SingularEvent):
         return {'active': payload.get_boolean()}
 
 
+class HackClubhouseNewsQuestLink(SingularEvent):
+    __tablename__ = 'hack_clubhouse_news_quest_link'
+    __event_uuid__ = 'ebffecb9-7b31-4c30-a9a0-f896aaaa5b4f'
+    __payload_type__ = '(ss)'
+
+    character = Column(Unicode, nullable=False)
+    quest = Column(Unicode, nullable=False)
+
+    @staticmethod
+    def _get_fields_from_payload(payload: GLib.Variant) -> Dict[str, Any]:
+        return {
+            'character': payload.get_child_value(0).get_string(),
+            'quest': payload.get_child_value(1).get_string(),
+        }
+
+
 class HackClubhouseProgress(SingularEvent):
     __tablename__ = 'hack_clubhouse_progress'
     __event_uuid__ = '3a037364-9164-4b42-8c07-73bcc00902de'

--- a/azafea/event_processors/metrics/tests/test_events.py
+++ b/azafea/event_processors/metrics/tests/test_events.py
@@ -199,6 +199,11 @@ def test_new_unknown_event():
     ('HackClubhouseEnterPathway', GLib.Variant('s', 'pathway'), {'pathway': 'pathway'}),
     ('HackClubhouseMode', GLib.Variant('b', True), {'active': True}),
     (
+        'HackClubhouseNewsQuestLink',
+        GLib.Variant('(ss)', ('character', 'quest')),
+        {'character': 'character', 'quest': 'quest'}
+    ),
+    (
         'HackClubhouseProgress',
         GLib.Variant('a{sv}', {
             'complete': GLib.Variant('b', True),

--- a/azafea/event_processors/metrics/v2/migrations/d0d01392a0ee_add_hack_news_quest_link_event.py
+++ b/azafea/event_processors/metrics/v2/migrations/d0d01392a0ee_add_hack_news_quest_link_event.py
@@ -1,0 +1,41 @@
+# type: ignore
+
+"""Add Hack news quest link event
+
+Revision ID: d0d01392a0ee
+Revises: f7b3720152d2
+Create Date: 2020-01-23 10:52:42.207139
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd0d01392a0ee'
+down_revision = 'f7b3720152d2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('hack_clubhouse_news_quest_link',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', sa.BigInteger(), nullable=False),
+                    sa.Column('occured_at', sa.DateTime(timezone=True), nullable=False),
+                    sa.Column('character', sa.Unicode(), nullable=False),
+                    sa.Column('quest', sa.Unicode(), nullable=False),
+                    sa.Column('request_id', sa.Integer(), nullable=True),
+                    sa.ForeignKeyConstraint(
+                        ['request_id'], ['metrics_request_v2.id'],
+                        name=op.f(
+                            'fk_hack_clubhouse_news_quest_link_request_id_metrics_request_v2')),
+                    sa.PrimaryKeyConstraint('id', name=op.f('pk_hack_clubhouse_news_quest_link')))
+    op.create_index(op.f('ix_hack_clubhouse_news_quest_link_request_id'),
+                    'hack_clubhouse_news_quest_link', ['request_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_hack_clubhouse_news_quest_link_request_id'),
+                  table_name='hack_clubhouse_news_quest_link')
+    op.drop_table('hack_clubhouse_news_quest_link')


### PR DESCRIPTION
This patch adds a new metric emitted in the Hack clubhouse to track user
engagement with the release notes inside the app. This will track the
quests launched from the hack news page links.

https://phabricator.endlessm.com/T29192