### PR TITLE
Parse the Endless image ids

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ pytest-flake8 = "*"
 pytest-mypy = ">=0.3.3"
 sphinx = "*"
 sqlalchemy-stubs = ">=0.3"
+typing-extensions = ">= 3.7.4"
 
 [packages]
 alembic = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "82a904d392db7c0dce8532239db4df2b89d2891d9506cb980e32e67d6cec1d50"
+            "sha256": "ab12f147690133c8140e3abfecb3655b450d75806ca8a33953bc2602beaeef23"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -561,6 +561,7 @@
                 "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d",
                 "sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575"
             ],
+            "index": "pypi",
             "version": "==3.7.4.1"
         },
         "urllib3": {

--- a/azafea/event_processors/endless/activation/tests/integration/test_activation_cli.py
+++ b/azafea/event_processors/endless/activation/tests/integration/test_activation_cli.py
@@ -46,8 +46,9 @@ class TestActivation(IntegrationTest):
         bad_vendor = 'EnDlEsS'
 
         with self.db as dbsession:
-            dbsession.add(Activation(image='image', product='product', release='release',
-                                     country='HKG', created_at=created_at, vendor=bad_vendor))
+            dbsession.add(Activation(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                     product='product', release='release', country='HKG',
+                                     created_at=created_at, vendor=bad_vendor))
 
         with self.db as dbsession:
             activation = dbsession.query(Activation).one()
@@ -74,8 +75,9 @@ class TestActivation(IntegrationTest):
         assert vendor == normalize_vendor(vendor)
 
         with self.db as dbsession:
-            dbsession.add(Activation(image='image', product='product', release='release',
-                                     country='HKG', created_at=created_at, vendor=vendor))
+            dbsession.add(Activation(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                     product='product', release='release', country='HKG',
+                                     created_at=created_at, vendor=vendor))
 
         with self.db as dbsession:
             activation = dbsession.query(Activation).one()

--- a/azafea/event_processors/endless/activation/tests/integration/test_activation_v1.py
+++ b/azafea/event_processors/endless/activation/tests/integration/test_activation_v1.py
@@ -26,7 +26,7 @@ class TestActivation(IntegrationTest):
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.redis.lpush('test_activation_v1', json.dumps({
-            'image': 'image',
+            'image': 'eos-eos3.7-amd64-amd64.190419-225606.base',
             'vendor': 'the vendor',
             'product': 'product',
             'release': 'release',
@@ -40,9 +40,81 @@ class TestActivation(IntegrationTest):
         # Ensure the record was inserted into the DB
         with self.db as dbsession:
             activation = dbsession.query(Activation).one()
-            assert activation.image == 'image'
+            assert activation.image == 'eos-eos3.7-amd64-amd64.190419-225606.base'
             assert activation.vendor == 'the vendor'
             assert activation.product == 'product'
             assert activation.release == 'release'
             assert activation.country == 'FRA'
             assert activation.created_at == created_at
+            assert activation.image_product == 'eos'
+            assert activation.image_branch == 'eos3.7'
+            assert activation.image_arch == 'amd64'
+            assert activation.image_platform == 'amd64'
+            assert activation.image_timestamp == datetime(2019, 4, 19, 22, 56, 6,
+                                                          tzinfo=timezone.utc)
+            assert activation.image_personality == 'base'
+
+    def test_activation_v1_unknown_image(self):
+        from azafea.event_processors.endless.activation.v1.handler import Activation
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Activation)
+
+        # Send an event to the Redis queue
+        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        self.redis.lpush('test_activation_v1_unknown_image', json.dumps({
+            'image': 'unknown',
+            'vendor': 'the vendor',
+            'product': 'product',
+            'release': 'release',
+            'country': 'FRA',
+            'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
+        }))
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            activation = dbsession.query(Activation).one()
+            assert activation.image == 'unknown'
+            assert activation.vendor == 'the vendor'
+            assert activation.product == 'product'
+            assert activation.release == 'release'
+            assert activation.country == 'FRA'
+            assert activation.created_at == created_at
+            assert activation.image_product is None
+            assert activation.image_branch is None
+            assert activation.image_arch is None
+            assert activation.image_platform is None
+            assert activation.image_timestamp is None
+            assert activation.image_personality is None
+
+    def test_activation_v1_invalid_image(self, capfd):
+        from azafea.event_processors.endless.activation.v1.handler import Activation
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Activation)
+
+        # Send an event to the Redis queue
+        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        self.redis.lpush('test_activation_v1', json.dumps({
+            'image': 'image',
+            'vendor': 'the vendor',
+            'product': 'product',
+            'release': 'release',
+            'country': 'FRA',
+            'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
+        }))
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was not inserted into the DB
+        with self.db as dbsession:
+            assert dbsession.query(Activation).count() == 0
+
+        capture = capfd.readouterr()
+        f"Invalid image id 'image': Did not match the expected format" in capture.err

--- a/azafea/event_processors/endless/activation/tests/test_activation_parsing.py
+++ b/azafea/event_processors/endless/activation/tests/test_activation_parsing.py
@@ -16,17 +16,23 @@ def test_from_bytes():
 
     created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
     activation = Activation.from_serialized(json.dumps({
-        'image': 'image',
+        'image': 'eos-eos3.7-amd64-amd64.190419-225606.base',
         'vendor': 'the vendor',
         'product': 'product',
         'release': 'release',
         'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
     }).encode('utf-8'))
 
-    assert activation.image == 'image'
+    assert activation.image == 'eos-eos3.7-amd64-amd64.190419-225606.base'
     assert activation.vendor == 'the vendor'
     assert activation.product == 'product'
     assert activation.release == 'release'
+    assert activation.image_product == 'eos'
+    assert activation.image_branch == 'eos3.7'
+    assert activation.image_arch == 'amd64'
+    assert activation.image_platform == 'amd64'
+    assert activation.image_timestamp == datetime(2019, 4, 19, 22, 56, 6, tzinfo=timezone.utc)
+    assert activation.image_personality == 'base'
 
     # SQLAlchemy only transforms the string into a datetime when querying from the DB
     assert activation.created_at == created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ')

--- a/azafea/event_processors/endless/activation/v1/migrations/3bf359e3c86c_store_the_parsed_image_components.py
+++ b/azafea/event_processors/endless/activation/v1/migrations/3bf359e3c86c_store_the_parsed_image_components.py
@@ -1,0 +1,57 @@
+# type: ignore
+
+"""Store the parsed image components
+
+Revision ID: 3bf359e3c86c
+Revises: 3666122efd41
+Create Date: 2020-02-03 16:03:19.957783
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3bf359e3c86c'
+down_revision = '3666122efd41'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('activation_v1', sa.Column('image_product', sa.Unicode(), nullable=True))
+    op.add_column('activation_v1', sa.Column('image_branch', sa.Unicode(), nullable=True))
+    op.add_column('activation_v1', sa.Column('image_arch', sa.Unicode(), nullable=True))
+    op.add_column('activation_v1', sa.Column('image_platform', sa.Unicode(), nullable=True))
+    op.add_column('activation_v1', sa.Column('image_timestamp', sa.DateTime(timezone=True),
+                                             nullable=True))
+    op.add_column('activation_v1', sa.Column('image_personality', sa.Unicode(), nullable=True))
+
+    op.create_index(op.f('ix_activation_v1_image_product'), 'activation_v1', ['image_product'],
+                    unique=False)
+    op.create_index(op.f('ix_activation_v1_image_branch'), 'activation_v1', ['image_branch'],
+                    unique=False)
+    op.create_index(op.f('ix_activation_v1_image_arch'), 'activation_v1', ['image_arch'],
+                    unique=False)
+    op.create_index(op.f('ix_activation_v1_image_platform'), 'activation_v1', ['image_platform'],
+                    unique=False)
+    op.create_index(op.f('ix_activation_v1_image_timestamp'), 'activation_v1', ['image_timestamp'],
+                    unique=False)
+    op.create_index(op.f('ix_activation_v1_image_personality'), 'activation_v1',
+                    ['image_personality'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_activation_v1_image_product'), table_name='activation_v1')
+    op.drop_index(op.f('ix_activation_v1_image_branch'), table_name='activation_v1')
+    op.drop_index(op.f('ix_activation_v1_image_arch'), table_name='activation_v1')
+    op.drop_index(op.f('ix_activation_v1_image_platform'), table_name='activation_v1')
+    op.drop_index(op.f('ix_activation_v1_image_timestamp'), table_name='activation_v1')
+    op.drop_index(op.f('ix_activation_v1_image_personality'), table_name='activation_v1')
+
+    op.drop_column('activation_v1', 'image_product')
+    op.drop_column('activation_v1', 'image_branch')
+    op.drop_column('activation_v1', 'image_arch')
+    op.drop_column('activation_v1', 'image_platform')
+    op.drop_column('activation_v1', 'image_timestamp')
+    op.drop_column('activation_v1', 'image_personality')

--- a/azafea/event_processors/endless/image.py
+++ b/azafea/event_processors/endless/image.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2020 - Endless
+#
+# This file is part of Azafea
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+from datetime import datetime, timezone
+import re
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:  # pragma: no cover
+    # FIXME: This can be taken from "typing" with Python 3.9.0:
+    #        https://github.com/python/typing/blob/2b4749c4d9c79dd2439a1cbdd00230ef9d9b56e3/typing_extensions/src_py3/typing_extensions.py#L1572-L1575
+    #        The fix might not be backported to a future 3.8.x:
+    #        https://github.com/python/cpython/pull/17214#issuecomment-557855088
+    from typing_extensions import TypedDict
+
+    class ParsedImage(TypedDict):
+        image_product: str
+        image_branch: str
+        image_arch: str
+        image_platform: str
+        image_timestamp: datetime
+        image_personality: str
+
+else:
+    ParsedImage = Dict
+
+
+IMAGE_PARSING_RE = r"""
+^                       # e.g: eos-3.7-amd64-amd64.190419-225606.base
+(?P<product>[^-]+)      # product: eos
+-
+(?P<branch>[^-]+)       # branch: 3.7
+-
+(?P<arch>[^-]+)         # arch: amd64
+-
+(?P<platform>[^-]+)     # platform: amd64
+\.
+(?P<date>\d{6}|\d{8,})  # date: 190419
+-
+(?P<time>\d{6})         # time: 225606
+\.
+(?P<personality>[^.]+)  # personality: base
+$"""
+IMAGE_PARSING_PATTERN = re.compile(IMAGE_PARSING_RE, re.VERBOSE)
+
+
+class ImageParsingError(Exception):
+    pass
+
+
+def parse_endless_os_image(image_id: str) -> ParsedImage:
+    match = IMAGE_PARSING_PATTERN.match(image_id)
+
+    if match is None:
+        raise ImageParsingError(
+                f'Invalid image id {image_id!r}: Did not match the expected format')
+
+    matched_date = match.group('date')
+
+    if len(matched_date) == 6:
+        # This is the current format, with the year on 2 digits; we'll eventually move to a format
+        # with the full year
+        matched_date = f'20{matched_date}'
+
+    try:
+        date = datetime.strptime(matched_date, '%Y%m%d')
+
+    except ValueError as e:
+        raise ImageParsingError(f'Invalid image id {image_id!r}: Could not parse the date: {e}')
+
+    try:
+        time = datetime.strptime(match.group('time'), '%H%M%S')
+
+    except ValueError as e:
+        raise ImageParsingError(f'Invalid image id {image_id!r}: Could not parse the time: {e}')
+
+    return {
+        'image_product': match.group('product'),
+        'image_branch': match.group('branch'),
+        'image_arch': match.group('arch'),
+        'image_platform': match.group('platform'),
+        'image_timestamp': datetime(date.year, date.month, date.day,
+                                    time.hour, time.minute, time.second,
+                                    tzinfo=timezone.utc),
+        'image_personality': match.group('personality'),
+    }

--- a/azafea/event_processors/endless/image.py
+++ b/azafea/event_processors/endless/image.py
@@ -45,6 +45,7 @@ IMAGE_PARSING_RE = r"""
 (?P<time>\d{6})         # time: 225606
 \.
 (?P<personality>[^.]+)  # personality: base
+(?:\.(?P<personality_again>[^.]+))?  # personality again, due to a temporary bug long ago
 $"""
 IMAGE_PARSING_PATTERN = re.compile(IMAGE_PARSING_RE, re.VERBOSE)
 

--- a/azafea/event_processors/endless/image.py
+++ b/azafea/event_processors/endless/image.py
@@ -31,20 +31,20 @@ else:
 
 
 IMAGE_PARSING_RE = r"""
-^                       # e.g: eos-3.7-amd64-amd64.190419-225606.base
-(?P<product>[^-]+)      # product: eos
+^                                    # e.g: eos-3.7-amd64-amd64.190419-225606.base
+(?P<product>[^-]+)                   # product: eos
 -
-(?P<branch>[^-]+)       # branch: 3.7
+(?P<branch>[^-]+)                    # branch: 3.7
 -
-(?P<arch>[^-]+)         # arch: amd64
+(?P<arch>[^-]+)                      # arch: amd64
 -
-(?P<platform>[^-]+)     # platform: amd64
+(?P<platform>[^-]+)                  # platform: amd64
 \.
-(?P<date>\d{6}|\d{8,})  # date: 190419
+(?P<date>\d{6}|\d{8,})               # date: 190419
 -
-(?P<time>\d{6})         # time: 225606
+(?P<time>\d{6})                      # time: 225606
 \.
-(?P<personality>[^.]+)  # personality: base
+(?P<personality>[^.]+)               # personality: base
 (?:\.(?P<personality_again>[^.]+))?  # personality again, due to a temporary bug long ago
 $"""
 IMAGE_PARSING_PATTERN = re.compile(IMAGE_PARSING_RE, re.VERBOSE)

--- a/azafea/event_processors/endless/image.py
+++ b/azafea/event_processors/endless/image.py
@@ -9,7 +9,7 @@
 
 from datetime import datetime, timezone
 import re
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, Optional
 
 if TYPE_CHECKING:  # pragma: no cover
     # FIXME: This can be taken from "typing" with Python 3.9.0:
@@ -19,12 +19,12 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing_extensions import TypedDict
 
     class ParsedImage(TypedDict):
-        image_product: str
-        image_branch: str
-        image_arch: str
-        image_platform: str
-        image_timestamp: datetime
-        image_personality: str
+        image_product: Optional[str]
+        image_branch: Optional[str]
+        image_arch: Optional[str]
+        image_platform: Optional[str]
+        image_timestamp: Optional[datetime]
+        image_personality: Optional[str]
 
 else:
     ParsedImage = Dict
@@ -55,6 +55,18 @@ class ImageParsingError(Exception):
 
 
 def parse_endless_os_image(image_id: str) -> ParsedImage:
+    if image_id == 'unknown':
+        # In case of errors, the activation and pings come with an "unknown" image id which we must
+        # treat as valid
+        return {
+            'image_product': None,
+            'image_branch': None,
+            'image_arch': None,
+            'image_platform': None,
+            'image_timestamp': None,
+            'image_personality': None,
+        }
+
     match = IMAGE_PARSING_PATTERN.match(image_id)
 
     if match is None:

--- a/azafea/event_processors/endless/metrics/machine.py
+++ b/azafea/event_processors/endless/metrics/machine.py
@@ -9,9 +9,11 @@
 
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.schema import Column
-from sqlalchemy.types import Integer, Unicode
+from sqlalchemy.types import DateTime, Integer, Unicode
 
 from azafea.model import Base, DbSession
+
+from ..image import parse_endless_os_image
 
 
 class Machine(Base):
@@ -20,10 +22,17 @@ class Machine(Base):
     id = Column(Integer, primary_key=True)
     machine_id = Column(Unicode(32), nullable=False, unique=True)
     image_id = Column(Unicode, nullable=False)
+    image_product = Column(Unicode, index=True)
+    image_branch = Column(Unicode, index=True)
+    image_arch = Column(Unicode, index=True)
+    image_platform = Column(Unicode, index=True)
+    image_timestamp = Column(DateTime(timezone=True), index=True)
+    image_personality = Column(Unicode, index=True)
 
 
 def insert_machine(dbsession: DbSession, machine_id: str, image_id: str) -> None:
-    stmt = insert(Machine.__table__).values(machine_id=machine_id, image_id=image_id)
+    stmt = insert(Machine.__table__).values(machine_id=machine_id, image_id=image_id,
+                                            **parse_endless_os_image(image_id))
     stmt = stmt.on_conflict_do_nothing()
 
     dbsession.connection().execute(stmt)

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
@@ -45,6 +45,7 @@ class TestMetrics(IntegrationTest):
         self.ensure_tables(Request, ImageVersion)
 
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
 
         with self.db as dbsession:
             dbsession.add(Request(serialized=b'whatever', sha512='sha512-1', received_at=occured_at,
@@ -69,7 +70,7 @@ class TestMetrics(IntegrationTest):
             with self.db as dbsession:
                 request = requests[i % 3]
                 dbsession.add(ImageVersion(request=request, user_id=i, occured_at=occured_at,
-                                           payload=GLib.Variant('mv', GLib.Variant('s', 'image'))))
+                                           payload=GLib.Variant('mv', GLib.Variant('s', image_id))))
 
         with self.db as dbsession:
             req1, req2, req3 = dbsession.query(Request).order_by(Request.id).all()

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_db_functions.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_db_functions.py
@@ -41,7 +41,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('migratedb')
         self.ensure_tables(ImageVersion, Machine, Request)
 
-        image_id = 'oem-os1.0-arch.base'
+        image_id = 'eosoem-eos3.7-amd64-amd64.190419-225606.base'
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         # Add a request with an image version
@@ -57,7 +57,7 @@ class TestMetrics(IntegrationTest):
         # Ensure this machine has the right product/personality
         with self.db as dbsession:
             product = dbsession.query(func.get_image_product(Request.machine_id)).one()[0]
-            assert product == 'oem'
+            assert product == 'eosoem'
             personality = dbsession.query(func.get_image_personality(Request.machine_id)).one()[0]
             assert personality == 'base'
 

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -195,7 +195,7 @@ class TestMetrics(IntegrationTest):
         # Build a request as it would have been sent to us
         now = datetime.now(tz=timezone.utc)
         machine_id = 'ffffffffffffffffffffffffffffffff'
-        image_id = 'oem-os1.0-arch.base'
+        image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
         user_id = 2000
         request = GLib.Variant(
             '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
@@ -485,6 +485,12 @@ class TestMetrics(IntegrationTest):
             machine = dbsession.query(Machine).one()
             assert machine.machine_id == machine_id
             assert machine.image_id == image_id
+            assert machine.image_product == 'eos'
+            assert machine.image_branch == 'eos3.7'
+            assert machine.image_arch == 'amd64'
+            assert machine.image_platform == 'amd64'
+            assert machine.image_timestamp == datetime(2019, 4, 19, 22, 56, 6, tzinfo=timezone.utc)
+            assert machine.image_personality == 'base'
 
             corrupted_cache = dbsession.query(CacheIsCorrupt).one()
             assert corrupted_cache.request_id == request.id
@@ -802,6 +808,63 @@ class TestMetrics(IntegrationTest):
         assert ('Metric event 56be0b38-e47b-4578-9599-00ff9bda54bb takes no payload, but got '
                 '<int64 2>') in capture.err
 
+    def test_machine_invalid_image_id(self, capfd):
+        from azafea.event_processors.endless.metrics.events import ImageVersion
+        from azafea.event_processors.endless.metrics.machine import Machine
+        from azafea.event_processors.endless.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request, Machine, ImageVersion)
+
+        # Build a request as it would have been sent to us
+        now = datetime.now(tz=timezone.utc)
+        machine_id = 'ffffffffffffffffffffffffffffffff'
+        image_id = 'image'
+        user_id = 2000
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id),
+                [                                      # singular events
+                    (
+                        user_id,
+                        UUID('6b1c1cfc-bc36-438c-0647-dacd5878f2b3').bytes,
+                        1000000000,                    # event relative timestamp (1 secs)
+                        GLib.Variant('s', image_id)
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_machine_invalid_image_id', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            assert dbsession.query(Request).order_by(Request.id).count() == 0
+            assert dbsession.query(Machine).order_by(Machine.id).count() == 0
+            assert dbsession.query(ImageVersion).order_by(ImageVersion.id).count() == 0
+
+        capture = capfd.readouterr()
+        assert f'Invalid image id {image_id!r}: Did not match the expected format' in capture.err
+
     def test_multiple_machines(self):
         from azafea.event_processors.endless.metrics.events import ImageVersion
         from azafea.event_processors.endless.metrics.machine import Machine
@@ -814,7 +877,7 @@ class TestMetrics(IntegrationTest):
         # Build a request as it would have been sent to us
         now = datetime.now(tz=timezone.utc)
         machine_id = 'ffffffffffffffffffffffffffffffff'
-        image_id = 'oem-os1.0-arch.base'
+        image_id = 'eosoem-eos3.7-amd64-amd64.190419-225606.base'
         user_id = 2000
         request = GLib.Variant(
             '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
@@ -850,7 +913,7 @@ class TestMetrics(IntegrationTest):
         # Build a request as it would have been sent to us
         now = datetime.now(tz=timezone.utc)
         machine_id = 'ffffffffffffffffffffffffffffffff'
-        image_id = 'oem-os1.0-arch.base'
+        image_id = 'eosoem-eos3.7-amd64-amd64.190419-225606.base'
         user_id = 2000
         request = GLib.Variant(
             '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
@@ -886,7 +949,7 @@ class TestMetrics(IntegrationTest):
         # Build a request as it would have been sent to us
         now = datetime.now(tz=timezone.utc)
         machine_id = '00000000000000000000000000000000'
-        image_id = 'oem-os1.1-arch.base'
+        image_id = 'eosoem-eos3.7-amd64-amd64.190419-225606.base'
         user_id = 2000
         request = GLib.Variant(
             '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
@@ -939,7 +1002,7 @@ class TestMetrics(IntegrationTest):
         # Build a request as it would have been sent to us
         now = datetime.now(tz=timezone.utc)
         machine_id = 'ffffffffffffffffffffffffffffffff'
-        image_id = 'oem-os1.0-arch.base'
+        image_id = 'eosoem-eos3.7-amd64-amd64.190419-225606.base'
         request = GLib.Variant(
             '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
             (

--- a/azafea/event_processors/endless/metrics/v2/migrations/3dc06459fc41_store_the_parsed_image_components_as_.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/3dc06459fc41_store_the_parsed_image_components_as_.py
@@ -1,0 +1,57 @@
+# type: ignore
+
+"""Store the parsed image components as attributes of the machine
+
+Revision ID: 3dc06459fc41
+Revises: d0d01392a0ee
+Create Date: 2020-02-03 13:55:47.869891
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3dc06459fc41'
+down_revision = 'd0d01392a0ee'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('metrics_machine', sa.Column('image_product', sa.Unicode(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('image_branch', sa.Unicode(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('image_arch', sa.Unicode(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('image_platform', sa.Unicode(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('image_timestamp', sa.DateTime(timezone=True),
+                                               nullable=True))
+    op.add_column('metrics_machine', sa.Column('image_personality', sa.Unicode(), nullable=True))
+
+    op.create_index(op.f('ix_metrics_machine_image_product'), 'metrics_machine', ['image_product'],
+                    unique=False)
+    op.create_index(op.f('ix_metrics_machine_image_branch'), 'metrics_machine', ['image_branch'],
+                    unique=False)
+    op.create_index(op.f('ix_metrics_machine_image_arch'), 'metrics_machine', ['image_arch'],
+                    unique=False)
+    op.create_index(op.f('ix_metrics_machine_image_platform'), 'metrics_machine',
+                    ['image_platform'], unique=False)
+    op.create_index(op.f('ix_metrics_machine_image_timestamp'), 'metrics_machine',
+                    ['image_timestamp'], unique=False)
+    op.create_index(op.f('ix_metrics_machine_image_personality'), 'metrics_machine',
+                    ['image_personality'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_metrics_machine_image_product'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_image_branch'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_image_arch'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_image_platform'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_image_timestamp'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_image_personality'), table_name='metrics_machine')
+
+    op.drop_column('metrics_machine', 'image_product')
+    op.drop_column('metrics_machine', 'image_branch')
+    op.drop_column('metrics_machine', 'image_arch')
+    op.drop_column('metrics_machine', 'image_platform')
+    op.drop_column('metrics_machine', 'image_timestamp')
+    op.drop_column('metrics_machine', 'image_personality')

--- a/azafea/event_processors/endless/ping/tests/integration/test_ping_cli.py
+++ b/azafea/event_processors/endless/ping/tests/integration/test_ping_cli.py
@@ -46,8 +46,9 @@ class TestPing(IntegrationTest):
         bad_vendor = 'EnDlEsS'
 
         with self.db as dbsession:
-            dbsession.add(PingConfiguration(image='image', product='product', dualboot=True,
-                                            created_at=created_at, vendor=bad_vendor))
+            dbsession.add(PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                            product='product', dualboot=True, created_at=created_at,
+                                            vendor=bad_vendor))
 
         with self.db as dbsession:
             ping_config = dbsession.query(PingConfiguration).one()
@@ -74,8 +75,9 @@ class TestPing(IntegrationTest):
         assert vendor == normalize_vendor(vendor)
 
         with self.db as dbsession:
-            dbsession.add(PingConfiguration(image='image', product='product', dualboot=True,
-                                            created_at=created_at, vendor=vendor))
+            dbsession.add(PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                            product='product', dualboot=True, created_at=created_at,
+                                            vendor=vendor))
 
         with self.db as dbsession:
             ping_config = dbsession.query(PingConfiguration).one()
@@ -99,8 +101,9 @@ class TestPing(IntegrationTest):
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            ping_config = PingConfiguration(image='image', product='product', dualboot=True,
-                                            created_at=created_at, vendor='EnDlEsS')
+            ping_config = PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                            product='product', dualboot=True, created_at=created_at,
+                                            vendor='EnDlEsS')
             dbsession.add(ping_config)
             dbsession.add(Ping(config=ping_config, release='release', count=0,
                                created_at=created_at))
@@ -110,8 +113,9 @@ class TestPing(IntegrationTest):
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            ping_config = PingConfiguration(image='image', product='product', dualboot=True,
-                                            created_at=created_at, vendor='eNdLeSs')
+            ping_config = PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                            product='product', dualboot=True, created_at=created_at,
+                                            vendor='eNdLeSs')
             dbsession.add(ping_config)
             dbsession.add(Ping(config=ping_config, release='release', count=0,
                                created_at=created_at))
@@ -162,8 +166,9 @@ class TestPing(IntegrationTest):
         bad_vendor = 'EnDlEsS'
 
         with self.db as dbsession:
-            ping_config = PingConfiguration(image='image', product='product', dualboot=True,
-                                            created_at=created_at, vendor=bad_vendor)
+            ping_config = PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                            product='product', dualboot=True, created_at=created_at,
+                                            vendor=bad_vendor)
             dbsession.add(ping_config)
             dbsession.add(Ping(config=ping_config, release='release', count=0,
                                created_at=created_at))
@@ -173,8 +178,9 @@ class TestPing(IntegrationTest):
         good_vendor = normalize_vendor(bad_vendor)
 
         with self.db as dbsession:
-            ping_config = PingConfiguration(image='image', product='product', dualboot=True,
-                                            created_at=created_at, vendor=good_vendor)
+            ping_config = PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                            product='product', dualboot=True, created_at=created_at,
+                                            vendor=good_vendor)
             dbsession.add(ping_config)
             dbsession.add(Ping(config=ping_config, release='release', count=1,
                                created_at=created_at))

--- a/azafea/event_processors/endless/ping/tests/integration/test_ping_v1.py
+++ b/azafea/event_processors/endless/ping/tests/integration/test_ping_v1.py
@@ -26,7 +26,7 @@ class TestPing(IntegrationTest):
         # Send an event to the Redis queue
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         self.redis.lpush('test_ping_v1', json.dumps({
-            'image': 'image',
+            'image': 'eos-eos3.7-amd64-amd64.190419-225606.base',
             'vendor': 'the vendor',
             'product': 'product',
             'dualboot': True,
@@ -41,11 +41,17 @@ class TestPing(IntegrationTest):
         # Ensure the record was inserted into the DB
         with self.db as dbsession:
             config = dbsession.query(PingConfiguration).one()
-            assert config.image == 'image'
+            assert config.image == 'eos-eos3.7-amd64-amd64.190419-225606.base'
             assert config.vendor == 'the vendor'
             assert config.product == 'product'
             assert config.dualboot is True
             assert config.created_at == created_at
+            assert config.image_product == 'eos'
+            assert config.image_branch == 'eos3.7'
+            assert config.image_arch == 'amd64'
+            assert config.image_platform == 'amd64'
+            assert config.image_timestamp == datetime(2019, 4, 19, 22, 56, 6, tzinfo=timezone.utc)
+            assert config.image_personality == 'base'
 
             ping = dbsession.query(Ping).one()
             assert ping.release == 'release'
@@ -63,7 +69,7 @@ class TestPing(IntegrationTest):
         created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         for i in range(10):
             self.redis.lpush('test_ping_configuration_v1_dualboot_unicity', json.dumps({
-                'image': 'image',
+                'image': 'eos-eos3.7-amd64-amd64.190419-225606.base',
                 'vendor': 'the vendor',
                 'product': 'product',
                 'dualboot': (True, False, None)[i % 3],
@@ -83,7 +89,7 @@ class TestPing(IntegrationTest):
             configs = configs.order_by(PingConfiguration.dualboot)
 
             for i, config in enumerate(configs):
-                assert config.image == 'image'
+                assert config.image == 'eos-eos3.7-amd64-amd64.190419-225606.base'
                 assert config.vendor == 'the vendor'
                 assert config.product == 'product'
                 assert config.dualboot == (True, False, None)[i % 3]
@@ -91,3 +97,75 @@ class TestPing(IntegrationTest):
 
             pings = dbsession.query(Ping)
             assert pings.count() == 10
+
+    def test_ping_v1_unknown_image(self):
+        from azafea.event_processors.endless.ping.v1.handler import PingConfiguration, Ping
+
+        # Create the tables
+        self.run_subcommand('initdb')
+        self.ensure_tables(Ping, PingConfiguration)
+
+        # Send an event to the Redis queue
+        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        self.redis.lpush('test_ping_v1_unknown_image', json.dumps({
+            'image': 'unknown',
+            'vendor': 'the vendor',
+            'product': 'product',
+            'dualboot': True,
+            'release': 'release',
+            'count': 0,
+            'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
+        }))
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            config = dbsession.query(PingConfiguration).one()
+            assert config.image == 'unknown'
+            assert config.vendor == 'the vendor'
+            assert config.product == 'product'
+            assert config.dualboot is True
+            assert config.created_at == created_at
+            assert config.image_product is None
+            assert config.image_branch is None
+            assert config.image_arch is None
+            assert config.image_platform is None
+            assert config.image_timestamp is None
+            assert config.image_personality is None
+
+            ping = dbsession.query(Ping).one()
+            assert ping.release == 'release'
+            assert ping.count == 0
+            assert ping.created_at == created_at
+
+    def test_ping_v1_invalid_image(self, capfd):
+        from azafea.event_processors.endless.ping.v1.handler import PingConfiguration, Ping
+
+        # Create the tables
+        self.run_subcommand('initdb')
+        self.ensure_tables(Ping, PingConfiguration)
+
+        # Send an event to the Redis queue
+        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        self.redis.lpush('test_ping_v1_invalid_image', json.dumps({
+            'image': 'image',
+            'vendor': 'the vendor',
+            'product': 'product',
+            'dualboot': True,
+            'release': 'release',
+            'count': 0,
+            'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
+        }))
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            assert dbsession.query(PingConfiguration).count() == 0
+            assert dbsession.query(Ping).count() == 0
+
+        capture = capfd.readouterr()
+        f"Invalid image id 'image': Did not match the expected format" in capture.err

--- a/azafea/event_processors/endless/ping/v1/handler.py
+++ b/azafea/event_processors/endless/ping/v1/handler.py
@@ -20,6 +20,8 @@ from sqlalchemy.types import Boolean, DateTime, Integer, Unicode
 from azafea.model import Base, DbSession, NullableBoolean
 from azafea.vendors import normalize_vendor
 
+from ...image import parse_endless_os_image
+
 
 log = logging.getLogger(__name__)
 
@@ -34,6 +36,13 @@ class PingConfiguration(Base):
     dualboot = Column(NullableBoolean, nullable=False, server_default='unknown')
     created_at = Column(DateTime(timezone=True), nullable=False, index=True)
 
+    image_product = Column(Unicode, index=True)
+    image_branch = Column(Unicode, index=True)
+    image_arch = Column(Unicode, index=True)
+    image_platform = Column(Unicode, index=True)
+    image_timestamp = Column(DateTime(timezone=True), index=True)
+    image_personality = Column(Unicode, index=True)
+
     __table_args__ = (
         UniqueConstraint(image, vendor, product, dualboot,
                          name='uq_ping_configuration_v1_image_vendor_product_dualboot'),
@@ -47,6 +56,10 @@ class PingConfiguration(Base):
         record = {k: v for (k, v) in record.items() if k in columns}
 
         record['vendor'] = normalize_vendor(record.get('vendor', 'unknown'))
+
+        # Let's make the case of a missing "image" fail at the SQL level
+        if 'image' in record:  # pragma: no branch
+            record.update(**parse_endless_os_image(record['image']))
 
         # Postgresql's 'INSERT … ON CONFLICT …' is not available at the ORM layer, so let's
         # drop down to the SQL layer

--- a/azafea/event_processors/endless/ping/v1/migrations/439e90a6874a_store_the_parsed_image_components.py
+++ b/azafea/event_processors/endless/ping/v1/migrations/439e90a6874a_store_the_parsed_image_components.py
@@ -1,0 +1,62 @@
+# type: ignore
+
+"""Store the parsed image components
+
+Revision ID: 439e90a6874a
+Revises: 0b3c2b3ae466
+Create Date: 2020-02-03 16:11:50.418656
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '439e90a6874a'
+down_revision = '0b3c2b3ae466'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('ping_configuration_v1', sa.Column('image_product', sa.Unicode(), nullable=True))
+    op.add_column('ping_configuration_v1', sa.Column('image_branch', sa.Unicode(), nullable=True))
+    op.add_column('ping_configuration_v1', sa.Column('image_arch', sa.Unicode(), nullable=True))
+    op.add_column('ping_configuration_v1', sa.Column('image_platform', sa.Unicode(), nullable=True))
+    op.add_column('ping_configuration_v1', sa.Column('image_timestamp', sa.DateTime(timezone=True),
+                                                     nullable=True))
+    op.add_column('ping_configuration_v1', sa.Column('image_personality', sa.Unicode(),
+                                                     nullable=True))
+
+    op.create_index(op.f('ix_ping_configuration_v1_image_product'), 'ping_configuration_v1',
+                    ['image_product'], unique=False)
+    op.create_index(op.f('ix_ping_configuration_v1_image_branch'), 'ping_configuration_v1',
+                    ['image_branch'], unique=False)
+    op.create_index(op.f('ix_ping_configuration_v1_image_arch'), 'ping_configuration_v1',
+                    ['image_arch'], unique=False)
+    op.create_index(op.f('ix_ping_configuration_v1_image_platform'), 'ping_configuration_v1',
+                    ['image_platform'], unique=False)
+    op.create_index(op.f('ix_ping_configuration_v1_image_timestamp'), 'ping_configuration_v1',
+                    ['image_timestamp'], unique=False)
+    op.create_index(op.f('ix_ping_configuration_v1_image_personality'), 'ping_configuration_v1',
+                    ['image_personality'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_ping_configuration_v1_image_product'),
+                  table_name='ping_configuration_v1')
+    op.drop_index(op.f('ix_ping_configuration_v1_image_branch'), table_name='ping_configuration_v1')
+    op.drop_index(op.f('ix_ping_configuration_v1_image_arch'), table_name='ping_configuration_v1')
+    op.drop_index(op.f('ix_ping_configuration_v1_image_platform'),
+                  table_name='ping_configuration_v1')
+    op.drop_index(op.f('ix_ping_configuration_v1_image_timestamp'),
+                  table_name='ping_configuration_v1')
+    op.drop_index(op.f('ix_ping_configuration_v1_image_personality'),
+                  table_name='ping_configuration_v1')
+
+    op.drop_column('ping_configuration_v1', 'image_product')
+    op.drop_column('ping_configuration_v1', 'image_branch')
+    op.drop_column('ping_configuration_v1', 'image_arch')
+    op.drop_column('ping_configuration_v1', 'image_platform')
+    op.drop_column('ping_configuration_v1', 'image_timestamp')
+    op.drop_column('ping_configuration_v1', 'image_personality')

--- a/azafea/event_processors/endless/tests/test_image.py
+++ b/azafea/event_processors/endless/tests/test_image.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2020 - Endless
+#
+# This file is part of Azafea
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.mark.parametrize('image_id, expected', [
+    (
+        'eos-eos3.7-armv7hl-ec100.190419-225606.base',
+        {
+            'image_product': 'eos',
+            'image_branch': 'eos3.7',
+            'image_arch': 'armv7hl',
+            'image_platform': 'ec100',
+            'image_timestamp': datetime(2019, 4, 19, 22, 56, 6, tzinfo=timezone.utc),
+            'image_personality': 'base'
+        }
+    ),
+    (
+        'eos-master-armv7hl-ec100.20190419-225606.pt_BR',
+        {
+            'image_product': 'eos',
+            'image_branch': 'master',
+            'image_arch': 'armv7hl',
+            'image_platform': 'ec100',
+            'image_timestamp': datetime(2019, 4, 19, 22, 56, 6, tzinfo=timezone.utc),
+            'image_personality': 'pt_BR'
+        }
+    ),
+])
+def test_parse_endless_os_image(image_id, expected):
+    from azafea.event_processors.endless.image import parse_endless_os_image
+
+    assert parse_endless_os_image(image_id) == expected
+
+
+@pytest.mark.parametrize('invalid_image_id', [
+    '',
+    'image',
+    '-master-armv7hl-ec100.190419-225606.base',
+    'eos--armv7hl-ec100.190419-225606.base',
+    'eos-master--ec100.190419-225606.base',
+    'eos-master-armv7hl-.190419-225606.base',
+    'eos-master-armv7hl-ec100.-225606.base',
+    'eos-master-armv7hl-ec100.19419-225606.base',
+    'eos-master-armv7hl-ec100.0190419-225606.base',
+    'eos-master-armv7hl-ec100.190419-.base',
+    'eos-master-armv7hl-ec100.190419-22566.base',
+    'eos-master-armv7hl-ec100.190419-1225606.base',
+    'eos-master-armv7hl-ec100.190419-225606.',
+])
+def test_parse_endless_os_invalid_image(invalid_image_id):
+    from azafea.event_processors.endless.image import ImageParsingError, parse_endless_os_image
+
+    with pytest.raises(ImageParsingError) as excinfo:
+        parse_endless_os_image(invalid_image_id)
+
+    assert (
+        f'Invalid image id {invalid_image_id!r}: Did not match the expected format'
+        ) in str(excinfo.value)
+
+
+@pytest.mark.parametrize('invalid_image_id', [
+    'eos-master-armv7hl-ec100.191319-225606.base',
+    'eos-master-armv7hl-ec100.20190431-225606.base',
+])
+def test_parse_endless_os_image_invalid_date(invalid_image_id):
+    from azafea.event_processors.endless.image import ImageParsingError, parse_endless_os_image
+
+    with pytest.raises(ImageParsingError) as excinfo:
+        parse_endless_os_image(invalid_image_id)
+
+    assert f'Invalid image id {invalid_image_id!r}: Could not parse the date' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('invalid_image_id', [
+    'eos-master-armv7hl-ec100.190419-245606.base',
+    'eos-master-armv7hl-ec100.190419-006306.base',
+    'eos-master-armv7hl-ec100.190419-225678.base',
+])
+def test_parse_endless_os_image_invalid_time(invalid_image_id):
+    from azafea.event_processors.endless.image import ImageParsingError, parse_endless_os_image
+
+    with pytest.raises(ImageParsingError) as excinfo:
+        parse_endless_os_image(invalid_image_id)
+
+    assert f'Invalid image id {invalid_image_id!r}: Could not parse the time' in str(excinfo.value)

--- a/azafea/event_processors/endless/tests/test_image.py
+++ b/azafea/event_processors/endless/tests/test_image.py
@@ -47,6 +47,17 @@ import pytest
             'image_personality': 'pt_BR'
         }
     ),
+    (
+        'unknown',
+        {
+            'image_product': None,
+            'image_branch': None,
+            'image_arch': None,
+            'image_platform': None,
+            'image_timestamp': None,
+            'image_personality': None
+        }
+    ),
 ])
 def test_parse_endless_os_image(image_id, expected):
     from azafea.event_processors.endless.image import parse_endless_os_image

--- a/azafea/event_processors/endless/tests/test_image.py
+++ b/azafea/event_processors/endless/tests/test_image.py
@@ -35,6 +35,18 @@ import pytest
             'image_personality': 'pt_BR'
         }
     ),
+    (
+        # Back in 2015-2016, due to a bug images were generated with the personality field repeated
+        'eos-master-armv7hl-ec100.20190419-225606.pt_BR.pt_BR',
+        {
+            'image_product': 'eos',
+            'image_branch': 'master',
+            'image_arch': 'armv7hl',
+            'image_platform': 'ec100',
+            'image_timestamp': datetime(2019, 4, 19, 22, 56, 6, tzinfo=timezone.utc),
+            'image_personality': 'pt_BR'
+        }
+    ),
 ])
 def test_parse_endless_os_image(image_id, expected):
     from azafea.event_processors.endless.image import parse_endless_os_image


### PR DESCRIPTION
The OS image id we receive in multiple events has a very specific format, with a few components, all of which are interesting to run queries on.

All the current Endless event processors are changed to do that, sotring the individual components of the image id in the appropriate table.

A specificity of the metrics events is that invalid image ids are never sent by the clients, whereas ping and activations are sent with the special `unknown` image id which need to be treated as valid records.

This also needs to account for an old, long fixed bug, which still generates ping and metrics records unfortunately.