### PR TITLE
docker: Preinstall setuptools and wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN apt --quiet --assume-yes update && \
         python3 \
         python3-dev \
         python3-pip \
+        python3-setuptools \
+        python3-wheel \
         && \
     pip3 install pipenv && \
     pipenv install --ignore-pipfile && \


### PR DESCRIPTION
Building the Docker image requires installing Pipenv, then using it to install the Azafea dependencies in a virtualenv.

The Azafea dependencies are pinned to specific versions, so every time we build the Docker image we get the exact same virtualenv, until we bump those dependencies.

However, Pipenv itself doesn't pin its dependencies, so we get the latest of each one of them.

This has no impact on what ends up in the virtualenv, which is correctly reproducible.

It does have an impact on installing Pipenv though, and this just happened and broke the build of our Docker image.

The latest Pipenv release (which we have been using for a while and hasn't changed) has the following requirements:

* certifi
* pip>=9.0.1
* setuptools>=36.2.1
* virtualenv
* virtualenv-clone>=0.2.5

A recent virtualenv release (20.0.2 on February 11 2020) added a dependency on distlib<1,>=0.3.0 which doesn't have a wheel available.

As a result, Pip tries to build a distlib egg-info and wheel to install it, which fails because setuptools hasn't been installed yet at this point.

This commit fixes that by installing setuptools early.