### PR TITLE
Parse old Endless images ids

### DIFF
--- a/azafea/event_processors/endless/activation/v1/cli.py
+++ b/azafea/event_processors/endless/activation/v1/cli.py
@@ -16,6 +16,7 @@ from azafea.model import Db
 from azafea.utils import progress
 from azafea.vendors import normalize_vendor
 
+from ...image import parse_endless_os_image
 from .handler import Activation
 
 
@@ -29,6 +30,13 @@ def register_commands(subs: argparse._SubParsersAction) -> None:
     normalize_vendors.add_argument('--chunk-size', type=int, default=5000,
                                    help='The size of the chunks to operate on')
     normalize_vendors.set_defaults(subcommand=do_normalize_vendors)
+
+    parse_images = subs.add_parser('parse-old-images',
+                                   help='Parse the image ids in existing records',
+                                   formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parse_images.add_argument('--chunk-size', type=int, default=5000,
+                              help='The size of the chunks to operate on')
+    parse_images.set_defaults(subcommand=do_parse_images)
 
 
 def _normalize_chunk(chunk: Query) -> None:
@@ -56,6 +64,36 @@ def do_normalize_vendors(config: Config, args: argparse.Namespace) -> None:
 
         for chunk_number, chunk in enumerate(query, start=1):
             _normalize_chunk(chunk)
+            dbsession.commit()
+            progress(chunk_number * args.chunk_size, num_records)
+
+    progress(num_records, num_records, end='\n')
+
+    log.info('All done!')
+
+
+def do_parse_images(config: Config, args: argparse.Namespace) -> None:
+    db = Db(config.postgresql)
+    log.info('Parsing the image ids for old activations')
+
+    with db as dbsession:
+        query = dbsession.chunked_query(Activation, chunk_size=args.chunk_size)
+        query = query.filter(Activation.image_product.is_(None))
+        query = query.filter(Activation.image != 'unknown')
+        query = query.reverse_chunks()
+        num_records = query.count()
+
+        if num_records == 0:
+            log.info('-> No activation record with unparsed image ids')
+            return None
+
+        for chunk_number, chunk in enumerate(query, start=1):
+            for activation in chunk:
+                parsed_image = parse_endless_os_image(activation.image)
+
+                for k, v in parsed_image.items():
+                    setattr(activation, k, v)
+
             dbsession.commit()
             progress(chunk_number * args.chunk_size, num_records)
 

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -1764,3 +1764,82 @@ class TestMetrics(IntegrationTest):
 
             assert dbsession.query(InvalidSequence).count() == 0
             assert dbsession.query(UserIsLoggedIn).count() == 0
+
+    def test_parse_old_images(self):
+        from azafea.event_processors.endless.metrics.machine import Machine
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Machine)
+
+        # Insert a machine without parsed image components
+        image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
+
+        with self.db as dbsession:
+            dbsession.add(Machine(machine_id='ffffffffffffffffffffffffffffffff', image_id=image_id))
+
+        with self.db as dbsession:
+            machine = dbsession.query(Machine).one()
+            assert machine.image_id == image_id
+            assert machine.image_product is None
+            assert machine.image_branch is None
+            assert machine.image_arch is None
+            assert machine.image_platform is None
+            assert machine.image_timestamp is None
+            assert machine.image_personality is None
+
+        # Parse the image for old machine records
+        self.run_subcommand('test_parse_old_images', 'parse-old-images')
+
+        with self.db as dbsession:
+            machine = dbsession.query(Machine).one()
+            assert machine.image_id == image_id
+            assert machine.image_product == 'eos'
+            assert machine.image_branch == 'eos3.7'
+            assert machine.image_arch == 'amd64'
+            assert machine.image_platform == 'amd64'
+            assert machine.image_timestamp == datetime(2019, 4, 19, 22, 56, 6, tzinfo=timezone.utc)
+            assert machine.image_personality == 'base'
+
+    def test_parse_old_images_skips_already_done(self, capfd):
+        from azafea.event_processors.endless.metrics.machine import Machine
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Machine)
+
+        # Insert a machine without parsed image components
+        image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
+
+        with self.db as dbsession:
+            dbsession.add(Machine(machine_id='ffffffffffffffffffffffffffffffff', image_id=image_id,
+                                  image_product='eos', image_branch='eos3.7', image_arch='amd64',
+                                  image_platform='amd64', image_personality='base',
+                                  image_timestamp=datetime(2019, 4, 19, 22, 56, 6,
+                                                           tzinfo=timezone.utc)))
+
+        with self.db as dbsession:
+            machine = dbsession.query(Machine).one()
+            assert machine.image_id == image_id
+            assert machine.image_product == 'eos'
+            assert machine.image_branch == 'eos3.7'
+            assert machine.image_arch == 'amd64'
+            assert machine.image_platform == 'amd64'
+            assert machine.image_timestamp == datetime(2019, 4, 19, 22, 56, 6, tzinfo=timezone.utc)
+            assert machine.image_personality == 'base'
+
+        # Parse the image for old machine records
+        self.run_subcommand('test_parse_old_images_skips_already_done', 'parse-old-images')
+
+        with self.db as dbsession:
+            machine = dbsession.query(Machine).one()
+            assert machine.image_id == image_id
+            assert machine.image_product == 'eos'
+            assert machine.image_branch == 'eos3.7'
+            assert machine.image_arch == 'amd64'
+            assert machine.image_platform == 'amd64'
+            assert machine.image_timestamp == datetime(2019, 4, 19, 22, 56, 6, tzinfo=timezone.utc)
+            assert machine.image_personality == 'base'
+
+        capture = capfd.readouterr()
+        assert 'No machine record with unparsed image ids' in capture.out

--- a/azafea/event_processors/endless/metrics/v2/cli.py
+++ b/azafea/event_processors/endless/metrics/v2/cli.py
@@ -17,6 +17,7 @@ from azafea.model import Db
 from azafea.utils import progress
 from azafea.vendors import normalize_vendor
 
+from ...image import parse_endless_os_image
 from ..events import (
     ImageVersion,
     InvalidAggregateEvent,
@@ -36,6 +37,7 @@ from ..events import (
     sequence_is_known,
     singular_event_is_known,
 )
+from ..machine import Machine
 
 
 log = logging.getLogger(__name__)
@@ -55,6 +57,13 @@ def register_commands(subs: argparse._SubParsersAction) -> None:
     normalize_vendors.add_argument('--chunk-size', type=int, default=5000,
                                    help='The size of the chunks to operate on')
     normalize_vendors.set_defaults(subcommand=do_normalize_vendors)
+
+    parse_images = subs.add_parser('parse-old-images',
+                                   help='Parse the image ids in existing records',
+                                   formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parse_images.add_argument('--chunk-size', type=int, default=5000,
+                              help='The size of the chunks to operate on')
+    parse_images.set_defaults(subcommand=do_parse_images)
 
     replay_invalid = subs.add_parser('replay-invalid', help='Replay invalid events',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -137,6 +146,35 @@ def do_normalize_vendors(config: Config, args: argparse.Namespace) -> None:
 
         for chunk_number, chunk in enumerate(query, start=1):
             _normalize_chunk(chunk)
+            dbsession.commit()
+            progress(chunk_number * args.chunk_size, num_records)
+
+    progress(num_records, num_records, end='\n')
+
+    log.info('All done!')
+
+
+def do_parse_images(config: Config, args: argparse.Namespace) -> None:
+    db = Db(config.postgresql)
+    log.info('Parsing the image ids for old activations')
+
+    with db as dbsession:
+        query = dbsession.chunked_query(Machine, chunk_size=args.chunk_size)
+        query = query.filter(Machine.image_product.is_(None))
+        query = query.reverse_chunks()
+        num_records = query.count()
+
+        if num_records == 0:
+            log.info('-> No machine record with unparsed image ids')
+            return None
+
+        for chunk_number, chunk in enumerate(query, start=1):
+            for machine in chunk:
+                parsed_image = parse_endless_os_image(machine.image_id)
+
+                for k, v in parsed_image.items():
+                    setattr(machine, k, v)
+
             dbsession.commit()
             progress(chunk_number * args.chunk_size, num_records)
 


### PR DESCRIPTION
In #89 we added new columns to the activation, metrics and ping models so that they store the individual components of the image ids, after parsing it.

This merge request introduces new management command to go over the old records, parse the image ids and store the results in the new columns.

---

@adarnimrod: we will need to run those commands after deploying the new Azafea. They can be run in parallel with Azafea running and receiving new events.

They might take a bit of time though, so we will finally be able to test my changes to make the progress output appear during the process in CloudWatch rather than all at the end. :slightly_smiling_face: 