### PR TITLE
metrics: Improve the image version deduplication

### DIFF
--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -8,7 +8,7 @@
 
 
 from operator import attrgetter
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from gi.repository import GLib
 
@@ -329,13 +329,27 @@ def receive_after_attach(dbsession: DbSession, instance: Base) -> None:
         return
 
     # So we have just added an ImageVersion to the session, let's only keep one new (pending)
-    image_versions = sorted(
-        (x for x in dbsession.new if isinstance(x, ImageVersion) and inspect(x).pending),
-        key=attrgetter('occured_at'))
-    to_expunge = image_versions[1:]
+    all_image_versions = (x for x in dbsession.new if isinstance(x, ImageVersion))
+    all_image_versions = (x for x in all_image_versions if inspect(x).pending)
 
-    for x in to_expunge:
-        dbsession.expunge(x)
+    image_versions_per_request: Dict[str, List[ImageVersion]] = {}
+
+    for image_version in all_image_versions:
+        # Requests don't have an id yet, because they have just been added to the db session which
+        # hasn't been committed yet; their sha512 is a good replacement identifier given that we
+        # have a unicity constraint on them
+        request_id = image_version.request.sha512
+
+        image_versions_per_request.setdefault(request_id, [])
+        image_versions_per_request[request_id].append(image_version)
+        image_versions_per_request[request_id].sort(key=attrgetter('occured_at'))
+
+    for _request_id, image_versions in image_versions_per_request.items():
+        # Keep only the first image version for each request
+        to_expunge = image_versions[1:]
+
+        for image_version in to_expunge:
+            dbsession.expunge(image_version)
 
 
 @listens_for(DbSession, 'before_commit')

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
@@ -63,12 +63,9 @@ class TestMetrics(IntegrationTest):
         # We have to do it this way because adding them all in the same session would get them
         # deduplicated before we ever had a chance to run the command.
 
-        with self.db as dbsession:
-            requests = dbsession.query(Request).order_by(Request.id).all()
-
         for i in range(9):
             with self.db as dbsession:
-                request = requests[i % 3]
+                request = dbsession.query(Request).order_by(Request.id).all()[i % 3]
                 dbsession.add(ImageVersion(request=request, user_id=i, occured_at=occured_at,
                                            payload=GLib.Variant('mv', GLib.Variant('s', image_id))))
 


### PR DESCRIPTION
The code was written to keep a single image version event for each database transaction… even if they came from different metrics requests.

This is wrong, and this commit fixes it so that we only keep a single image version event per request.

The risk is theoretical at the moment because Azafea processes one request at a time, so the metrics request and the db session effectively have the same life cycle.

However, this has the potential to blow and cause data loss due to changes in the future if we changed that, so let's fix it now before it causes trouble.