### PR TITLE
metrics: Add a command to replay past image version events

### DIFF
--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
@@ -185,6 +185,80 @@ class TestMetrics(IntegrationTest):
             event = dbsession.query(UpdaterBranchSelected).one()
             assert event.hardware_vendor == vendor
 
+    def test_replay_machine_images(self):
+        from azafea.event_processors.endless.metrics.events import ImageVersion
+        from azafea.event_processors.endless.metrics.machine import Machine
+        from azafea.event_processors.endless.metrics.request import Request
+
+        self.run_subcommand('initdb')
+        self.ensure_tables(ImageVersion, Machine, Request)
+
+        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        with self.db as dbsession:
+            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
+                              send_number=0)
+            dbsession.add(request)
+
+            image_id_1 = 'eos-eos3.6-amd64-amd64.190619-225606.base'
+            dbsession.add(ImageVersion(request=request, user_id=1001, occured_at=occured_at,
+                                       payload=GLib.Variant('mv', GLib.Variant('s', image_id_1))))
+
+            request = Request(serialized=b'whatever2', sha512='whatever2', received_at=occured_at,
+                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
+                              send_number=0)
+            dbsession.add(request)
+
+            image_id_2 = 'eos-eos3.7-amd64-amd64.191019-225606.base'
+            dbsession.add(ImageVersion(request=request, user_id=1001, occured_at=occured_at,
+                                       payload=GLib.Variant('mv', GLib.Variant('s', image_id_2))))
+
+        # Pretend these events had been received before we created the Machine model by simply
+        # removing them
+        with self.db as dbsession:
+            dbsession.query(Machine).delete()
+
+        with self.db as dbsession:
+            assert dbsession.query(Request).count() == 2
+            assert dbsession.query(ImageVersion).count() == 2
+            assert dbsession.query(Machine).count() == 0
+
+        # The machine1 has sent a new event after creating the Machine model, but before running
+        # the replay command
+        with self.db as dbsession:
+            request = Request(serialized=b'whatever3', sha512='whatever3', received_at=occured_at,
+                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
+                              send_number=0)
+            dbsession.add(request)
+
+            dbsession.add(ImageVersion(request=request, user_id=1001, occured_at=occured_at,
+                                       payload=GLib.Variant('mv', GLib.Variant('s', image_id_1))))
+
+        with self.db as dbsession:
+            assert dbsession.query(Request).count() == 3
+            assert dbsession.query(ImageVersion).count() == 3
+            assert dbsession.query(Machine).count() == 1
+            assert dbsession.query(Machine).one().machine_id == 'machine1'
+
+        # Replay the image version events
+        self.run_subcommand('test_replay_machine_images', 'replay-machine-images', '--chunk-size=2')
+
+        with self.db as dbsession:
+            assert dbsession.query(Request).count() == 3
+            assert dbsession.query(ImageVersion).count() == 3
+            assert dbsession.query(Machine).count() == 2
+
+            machines = dbsession.query(Machine).order_by(Machine.machine_id).all()
+
+            machine = machines[0]
+            assert machine.machine_id == 'machine1'
+            assert machine.image_id == image_id_1
+
+            machine = machines[1]
+            assert machine.machine_id == 'machine2'
+            assert machine.image_id == image_id_2
+
     def test_replay_invalid(self):
         from azafea.event_processors.endless.metrics.events import ShellAppIsOpen, Uptime
         from azafea.event_processors.endless.metrics.events._base import (


### PR DESCRIPTION
This is necessary to populate the machine mapping table without waiting for a new image version event from each deployed machine, some of which connect to the Internet very infrequently.