### PR TITLE
metrics: Fix progress reporting for a command

### DIFF
--- a/azafea/event_processors/endless/metrics/v2/cli.py
+++ b/azafea/event_processors/endless/metrics/v2/cli.py
@@ -254,7 +254,7 @@ def do_replay_machine_images(config: Config, args: argparse.Namespace) -> None:
 
             if (i % args.chunk_size) == 0:
                 dbsession.commit()
-                progress(i * args.chunk_size, total)
+                progress(i, total)
 
         progress(total, total)
 


### PR DESCRIPTION
Too bad I caught the problem when running the command in production. /o\