### PR TITLE
metrics: Add live, demo and dualboot as property of the machines

### DIFF
--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -19,7 +19,7 @@ from sqlalchemy.types import ARRAY, BigInteger, Boolean, Integer, LargeBinary, N
 
 from azafea.model import Base, DbSession
 from azafea.vendors import normalize_vendor
-from ..machine import insert_machine
+from ..machine import upsert_machine_image
 from ..utils import get_asv_dict, get_bytes, get_child_values, get_strings
 from ._base import (  # noqa: F401
     SequenceEvent,
@@ -717,4 +717,4 @@ def receive_after_attach(dbsession: DbSession, instance: Base) -> None:
 def receive_before_commit(dbsession: DbSession) -> None:
     for instance in dbsession.new:
         if isinstance(instance, ImageVersion):
-            insert_machine(dbsession, instance.request.machine_id, image_id=instance.image_id)
+            upsert_machine_image(dbsession, instance.request.machine_id, image_id=instance.image_id)

--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -19,7 +19,7 @@ from sqlalchemy.types import ARRAY, BigInteger, Boolean, Integer, LargeBinary, N
 
 from azafea.model import Base, DbSession
 from azafea.vendors import normalize_vendor
-from ..machine import upsert_machine_dualboot, upsert_machine_image
+from ..machine import upsert_machine_dualboot, upsert_machine_image, upsert_machine_live
 from ..utils import get_asv_dict, get_bytes, get_child_values, get_strings
 from ._base import (  # noqa: F401
     SequenceEvent,
@@ -721,3 +721,6 @@ def receive_before_commit(dbsession: DbSession) -> None:
 
         elif isinstance(instance, DualBootBooted):
             upsert_machine_dualboot(dbsession, instance.request.machine_id)
+
+        elif isinstance(instance, LiveUsbBooted):
+            upsert_machine_live(dbsession, instance.request.machine_id)

--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -184,6 +184,12 @@ class EndlessApplicationUnmaximized(SingularEvent):
         return {'app_id': payload.get_string()}
 
 
+class EnteredDemoMode(SingularEvent):
+    __tablename__ = 'entered_demo_mode'
+    __event_uuid__ = 'c75af67f-cf2f-433d-a060-a670087d93a1'
+    __payload_type__ = None
+
+
 class HackClubhouseAchievement(SingularEvent):
     __tablename__ = 'hack_clubhouse_achievement'
     __event_uuid__ = '62ce2e93-bfdc-4cae-af4c-54068abfaf02'

--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -19,7 +19,12 @@ from sqlalchemy.types import ARRAY, BigInteger, Boolean, Integer, LargeBinary, N
 
 from azafea.model import Base, DbSession
 from azafea.vendors import normalize_vendor
-from ..machine import upsert_machine_dualboot, upsert_machine_image, upsert_machine_live
+from ..machine import (
+    upsert_machine_demo,
+    upsert_machine_dualboot,
+    upsert_machine_image,
+    upsert_machine_live,
+)
 from ..utils import get_asv_dict, get_bytes, get_child_values, get_strings
 from ._base import (  # noqa: F401
     SequenceEvent,
@@ -727,6 +732,9 @@ def receive_before_commit(dbsession: DbSession) -> None:
 
         elif isinstance(instance, DualBootBooted):
             upsert_machine_dualboot(dbsession, instance.request.machine_id)
+
+        elif isinstance(instance, EnteredDemoMode):
+            upsert_machine_demo(dbsession, instance.request.machine_id)
 
         elif isinstance(instance, LiveUsbBooted):
             upsert_machine_live(dbsession, instance.request.machine_id)

--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -716,7 +716,5 @@ def receive_after_attach(dbsession: DbSession, instance: Base) -> None:
 @listens_for(DbSession, 'before_commit')
 def receive_before_commit(dbsession: DbSession) -> None:
     for instance in dbsession.new:
-        if not isinstance(instance, ImageVersion):
-            continue
-
-        insert_machine(dbsession, instance.request.machine_id, image_id=instance.image_id)
+        if isinstance(instance, ImageVersion):
+            insert_machine(dbsession, instance.request.machine_id, image_id=instance.image_id)

--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -19,7 +19,7 @@ from sqlalchemy.types import ARRAY, BigInteger, Boolean, Integer, LargeBinary, N
 
 from azafea.model import Base, DbSession
 from azafea.vendors import normalize_vendor
-from ..machine import upsert_machine_image
+from ..machine import upsert_machine_dualboot, upsert_machine_image
 from ..utils import get_asv_dict, get_bytes, get_child_values, get_strings
 from ._base import (  # noqa: F401
     SequenceEvent,
@@ -718,3 +718,6 @@ def receive_before_commit(dbsession: DbSession) -> None:
     for instance in dbsession.new:
         if isinstance(instance, ImageVersion):
             upsert_machine_image(dbsession, instance.request.machine_id, image_id=instance.image_id)
+
+        elif isinstance(instance, DualBootBooted):
+            upsert_machine_dualboot(dbsession, instance.request.machine_id)

--- a/azafea/event_processors/endless/metrics/machine.py
+++ b/azafea/event_processors/endless/metrics/machine.py
@@ -31,8 +31,17 @@ class Machine(Base):
     image_platform = Column(Unicode, index=True)
     image_timestamp = Column(DateTime(timezone=True), index=True)
     image_personality = Column(Unicode, index=True)
+    demo = Column(Boolean, server_default=expression.false())
     dualboot = Column(Boolean, server_default=expression.false())
     live = Column(Boolean, server_default=expression.false())
+
+
+def upsert_machine_demo(dbsession: DbSession, machine_id: str) -> None:
+    stmt = insert(Machine.__table__).values(machine_id=machine_id, demo=True)
+    stmt = stmt.on_conflict_do_update(constraint='uq_metrics_machine_machine_id',
+                                      set_={'demo': True})
+
+    dbsession.connection().execute(stmt)
 
 
 def upsert_machine_dualboot(dbsession: DbSession, machine_id: str) -> None:

--- a/azafea/event_processors/endless/metrics/machine.py
+++ b/azafea/event_processors/endless/metrics/machine.py
@@ -11,7 +11,8 @@ from typing import Any, Dict
 
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.schema import Column
-from sqlalchemy.types import DateTime, Integer, Unicode
+from sqlalchemy.sql import expression
+from sqlalchemy.types import Boolean, DateTime, Integer, Unicode
 
 from azafea.model import Base, DbSession
 
@@ -30,6 +31,15 @@ class Machine(Base):
     image_platform = Column(Unicode, index=True)
     image_timestamp = Column(DateTime(timezone=True), index=True)
     image_personality = Column(Unicode, index=True)
+    dualboot = Column(Boolean, server_default=expression.false())
+
+
+def upsert_machine_dualboot(dbsession: DbSession, machine_id: str) -> None:
+    stmt = insert(Machine.__table__).values(machine_id=machine_id, dualboot=True)
+    stmt = stmt.on_conflict_do_update(constraint='uq_metrics_machine_machine_id',
+                                      set_={'dualboot': True})
+
+    dbsession.connection().execute(stmt)
 
 
 def upsert_machine_image(dbsession: DbSession, machine_id: str, image_id: str) -> None:

--- a/azafea/event_processors/endless/metrics/machine.py
+++ b/azafea/event_processors/endless/metrics/machine.py
@@ -32,6 +32,7 @@ class Machine(Base):
     image_timestamp = Column(DateTime(timezone=True), index=True)
     image_personality = Column(Unicode, index=True)
     dualboot = Column(Boolean, server_default=expression.false())
+    live = Column(Boolean, server_default=expression.false())
 
 
 def upsert_machine_dualboot(dbsession: DbSession, machine_id: str) -> None:
@@ -47,5 +48,13 @@ def upsert_machine_image(dbsession: DbSession, machine_id: str, image_id: str) -
 
     stmt = insert(Machine.__table__).values(machine_id=machine_id, **image_values)
     stmt = stmt.on_conflict_do_update(constraint='uq_metrics_machine_machine_id', set_=image_values)
+
+    dbsession.connection().execute(stmt)
+
+
+def upsert_machine_live(dbsession: DbSession, machine_id: str) -> None:
+    stmt = insert(Machine.__table__).values(machine_id=machine_id, live=True)
+    stmt = stmt.on_conflict_do_update(constraint='uq_metrics_machine_machine_id',
+                                      set_={'live': True})
 
     dbsession.connection().execute(stmt)

--- a/azafea/event_processors/endless/metrics/machine.py
+++ b/azafea/event_processors/endless/metrics/machine.py
@@ -21,7 +21,7 @@ class Machine(Base):
 
     id = Column(Integer, primary_key=True)
     machine_id = Column(Unicode(32), nullable=False, unique=True)
-    image_id = Column(Unicode, nullable=False)
+    image_id = Column(Unicode)
     image_product = Column(Unicode, index=True)
     image_branch = Column(Unicode, index=True)
     image_arch = Column(Unicode, index=True)

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
@@ -466,6 +466,81 @@ class TestMetrics(IntegrationTest):
             assert machine.machine_id == 'machine2'
             assert machine.image_id == image_id_2
 
+    def test_replay_machine_live_usbs(self):
+        from azafea.event_processors.endless.metrics.events import LiveUsbBooted
+        from azafea.event_processors.endless.metrics.machine import Machine
+        from azafea.event_processors.endless.metrics.request import Request
+
+        self.run_subcommand('initdb')
+        self.ensure_tables(LiveUsbBooted, Machine, Request)
+
+        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        with self.db as dbsession:
+            request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
+                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
+                              send_number=0)
+            dbsession.add(request)
+
+            request = Request(serialized=b'whatever2', sha512='whatever2', received_at=occured_at,
+                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
+                              send_number=0)
+            dbsession.add(request)
+            dbsession.add(LiveUsbBooted(request=request, user_id=1001, occured_at=occured_at,
+                                        payload=GLib.Variant('mv', None)))
+
+            request = Request(serialized=b'whatever3', sha512='whatever3', received_at=occured_at,
+                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine3',
+                              send_number=0)
+            dbsession.add(request)
+            dbsession.add(LiveUsbBooted(request=request, user_id=1001, occured_at=occured_at,
+                                        payload=GLib.Variant('mv', None)))
+
+        # Pretend these events had been received before we created the Machine model by simply
+        # removing them
+        with self.db as dbsession:
+            dbsession.query(Machine).delete()
+
+        with self.db as dbsession:
+            assert dbsession.query(Request).count() == 3
+            assert dbsession.query(LiveUsbBooted).count() == 2
+            assert dbsession.query(Machine).count() == 0
+
+        # The machine2 has sent a new event after creating the Machine model, but before running
+        # the replay command
+        with self.db as dbsession:
+            request = Request(serialized=b'whatever4', sha512='whatever4', received_at=occured_at,
+                              absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
+                              send_number=0)
+            dbsession.add(request)
+            dbsession.add(LiveUsbBooted(request=request, user_id=1001, occured_at=occured_at,
+                                        payload=GLib.Variant('mv', None)))
+
+        with self.db as dbsession:
+            assert dbsession.query(Request).count() == 4
+            assert dbsession.query(LiveUsbBooted).count() == 3
+            assert dbsession.query(Machine).count() == 1
+            assert dbsession.query(Machine).one().machine_id == 'machine2'
+
+        # Replay the image version events
+        self.run_subcommand('test_replay_machine_live_usbs', 'replay-machine-live-usbs',
+                            '--chunk-size=2')
+
+        with self.db as dbsession:
+            assert dbsession.query(Request).count() == 4
+            assert dbsession.query(LiveUsbBooted).count() == 3
+            assert dbsession.query(Machine).count() == 2
+
+            machines = dbsession.query(Machine).order_by(Machine.machine_id).all()
+
+            machine = machines[0]
+            assert machine.machine_id == 'machine2'
+            assert machine.live is True
+
+            machine = machines[1]
+            assert machine.machine_id == 'machine3'
+            assert machine.live is True
+
     def test_replay_invalid(self):
         from azafea.event_processors.endless.metrics.events import ShellAppIsOpen, Uptime
         from azafea.event_processors.endless.metrics.events._base import (

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -1119,14 +1119,14 @@ class TestMetrics(IntegrationTest):
             assert machine.live is True
             assert machine.demo is False
 
-    def test_multiple_machines(self):
-        from azafea.event_processors.endless.metrics.events import ImageVersion
+    def test_upsert_machine_image_id_then_dualboot(self):
+        from azafea.event_processors.endless.metrics.events import DualBootBooted, ImageVersion
         from azafea.event_processors.endless.metrics.machine import Machine
         from azafea.event_processors.endless.metrics.request import Request
 
         # Create the table
         self.run_subcommand('initdb')
-        self.ensure_tables(Request, Machine, ImageVersion)
+        self.ensure_tables(Request, Machine, DualBootBooted, ImageVersion)
 
         # Build a request as it would have been sent to us
         now = datetime.now(tz=timezone.utc)
@@ -1162,7 +1162,133 @@ class TestMetrics(IntegrationTest):
         record = received_at_timestamp_bytes + request_body
 
         # Send the event request to the Redis queue
-        self.redis.lpush('test_multiple_machines', record)
+        self.redis.lpush('test_upsert_machine_image_id_then_dualboot', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).one()
+
+            image = dbsession.query(ImageVersion).one()
+            assert image.request_id == request.id
+            assert image.image_id == image_id
+
+            machine = dbsession.query(Machine).one()
+            assert machine.machine_id == request.machine_id
+            assert machine.image_id == image_id
+            assert machine.dualboot is False
+            assert machine.live is False
+
+        # Build a request as it would have been sent to us
+        now = datetime.now(tz=timezone.utc)
+        machine_id = 'ffffffffffffffffffffffffffffffff'
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id),
+                [                                      # singular events
+                    (
+                        1001,
+                        UUID('16cfc671-5525-4a99-9eb9-4f6c074803a9').bytes,
+                        2000000000,                    # event relative timestamp (2 secs)
+                        None
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_upsert_machine_image_id_then_dualboot', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).order_by(Request.received_at.desc()).first()
+
+            dualboot = dbsession.query(DualBootBooted).one()
+            assert dualboot.request_id == request.id
+
+            machine = dbsession.query(Machine).one()
+            assert machine.machine_id == request.machine_id
+            assert machine.image_id == image_id
+            assert machine.dualboot is True
+            assert machine.live is False
+
+    def test_upsert_machine_live_then_image_id(self):
+        from azafea.event_processors.endless.metrics.events import ImageVersion, LiveUsbBooted
+        from azafea.event_processors.endless.metrics.machine import Machine
+        from azafea.event_processors.endless.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request, Machine, ImageVersion, LiveUsbBooted)
+
+        # Build a request as it would have been sent to us
+        now = datetime.now(tz=timezone.utc)
+        machine_id = 'ffffffffffffffffffffffffffffffff'
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id),
+                [                                      # singular events
+                    (
+                        1001,
+                        UUID('56be0b38-e47b-4578-9599-00ff9bda54bb').bytes,
+                        2000000000,                    # event relative timestamp (2 secs)
+                        None
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_upsert_machine_live_then_image_id', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).one()
+
+            live = dbsession.query(LiveUsbBooted).one()
+            assert live.request_id == request.id
+
+            machine = dbsession.query(Machine).one()
+            assert machine.machine_id == request.machine_id
+            assert machine.image_id is None
+            assert machine.dualboot is False
+            assert machine.live is True
 
         # Build a request as it would have been sent to us
         now = datetime.now(tz=timezone.utc)
@@ -1180,7 +1306,7 @@ class TestMetrics(IntegrationTest):
                     (
                         user_id,
                         UUID('6b1c1cfc-bc36-438c-0647-dacd5878f2b3').bytes,
-                        3000000000,                    # event relative timestamp (3 secs)
+                        1000000000,                    # event relative timestamp (1 secs)
                         GLib.Variant('s', image_id)
                     ),
                 ],
@@ -1198,11 +1324,39 @@ class TestMetrics(IntegrationTest):
         record = received_at_timestamp_bytes + request_body
 
         # Send the event request to the Redis queue
-        self.redis.lpush('test_multiple_machines', record)
+        self.redis.lpush('test_upsert_machine_live_then_image_id', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).order_by(Request.received_at.desc()).first()
+
+            image = dbsession.query(ImageVersion).one()
+            assert image.request_id == request.id
+            assert image.image_id == image_id
+
+            machine = dbsession.query(Machine).one()
+            assert machine.machine_id == request.machine_id
+            assert machine.image_id == image_id
+            assert machine.dualboot is False
+            assert machine.live is True
+
+    def test_upsert_machine_all_at_once(self):
+        from azafea.event_processors.endless.metrics.events import (
+            DualBootBooted, EnteredDemoMode, ImageVersion, LiveUsbBooted)
+        from azafea.event_processors.endless.metrics.machine import Machine
+        from azafea.event_processors.endless.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request, Machine, DualBootBooted, EnteredDemoMode, ImageVersion,
+                           LiveUsbBooted)
 
         # Build a request as it would have been sent to us
         now = datetime.now(tz=timezone.utc)
-        machine_id = '00000000000000000000000000000000'
+        machine_id = 'ffffffffffffffffffffffffffffffff'
         image_id = 'eosoem-eos3.7-amd64-amd64.190419-225606.base'
         user_id = 2000
         request = GLib.Variant(
@@ -1216,8 +1370,26 @@ class TestMetrics(IntegrationTest):
                     (
                         user_id,
                         UUID('6b1c1cfc-bc36-438c-0647-dacd5878f2b3').bytes,
-                        4000000000,                    # event relative timestamp (4 secs)
+                        1000000000,                    # event relative timestamp (1 secs)
                         GLib.Variant('s', image_id)
+                    ),
+                    (
+                        1001,
+                        UUID('16cfc671-5525-4a99-9eb9-4f6c074803a9').bytes,
+                        2000000000,                    # event relative timestamp (2 secs)
+                        None
+                    ),
+                    (
+                        1001,
+                        UUID('56be0b38-e47b-4578-9599-00ff9bda54bb').bytes,
+                        2000000000,                    # event relative timestamp (3 secs)
+                        None
+                    ),
+                    (
+                        1001,
+                        UUID('c75af67f-cf2f-433d-a060-a670087d93a1').bytes,
+                        2000000000,                    # event relative timestamp (4 secs)
+                        None
                     ),
                 ],
                 [],                                    # aggregate events
@@ -1234,16 +1406,207 @@ class TestMetrics(IntegrationTest):
         record = received_at_timestamp_bytes + request_body
 
         # Send the event request to the Redis queue
-        self.redis.lpush('test_multiple_machines', record)
+        self.redis.lpush('test_upsert_machine_all_at_once', record)
 
         # Run Azafea so it processes the event
         self.run_azafea()
 
         # Ensure the record was inserted into the DB
         with self.db as dbsession:
-            assert dbsession.query(Request).order_by(Request.id).count() == 3
-            assert dbsession.query(Machine).order_by(Machine.id).count() == 2
-            assert dbsession.query(ImageVersion).order_by(ImageVersion.id).count() == 3
+            request = dbsession.query(Request).one()
+
+            live = dbsession.query(LiveUsbBooted).one()
+            assert live.request_id == request.id
+
+            machine = dbsession.query(Machine).one()
+            assert machine.machine_id == request.machine_id
+            assert machine.image_id == image_id
+            assert machine.dualboot is True
+            assert machine.live is True
+            assert machine.demo is True
+
+    def test_upsert_multiple_machines(self):
+        from azafea.event_processors.endless.metrics.events import (
+            DualBootBooted, EnteredDemoMode, ImageVersion, LiveUsbBooted)
+        from azafea.event_processors.endless.metrics.machine import Machine
+        from azafea.event_processors.endless.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request, Machine, DualBootBooted, EnteredDemoMode, ImageVersion,
+                           LiveUsbBooted)
+
+        # Build a request as it would have been sent to us, with an image version event
+        now = datetime.now(tz=timezone.utc)
+        machine_id_1 = 'ffffffffffffffffffffffffffffffff'
+        image_id_1 = 'eosoem-eos3.7-amd64-amd64.190419-225606.base'
+        user_id = 2000
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id_1),
+                [                                      # singular events
+                    (
+                        user_id,
+                        UUID('6b1c1cfc-bc36-438c-0647-dacd5878f2b3').bytes,
+                        1000000000,                    # event relative timestamp (1 secs)
+                        GLib.Variant('s', image_id_1)
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=1)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_upsert_multiple_machines', record)
+
+        # Build a request as it would have been sent to us, with an image version and a live events
+        user_id = 2000
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id_1),
+                [                                      # singular events
+                    (
+                        user_id,
+                        UUID('6b1c1cfc-bc36-438c-0647-dacd5878f2b3').bytes,
+                        3000000000,                    # event relative timestamp (3 secs)
+                        GLib.Variant('s', image_id_1)
+                    ),
+                    (
+                        user_id,
+                        UUID('56be0b38-e47b-4578-9599-00ff9bda54bb').bytes,
+                        2000000000,                    # event relative timestamp (2 secs)
+                        None
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_upsert_multiple_machines', record)
+
+        # Build a request as it would have been sent to us, with a dualboot event
+        machine_id_2 = '00000000000000000000000000000000'
+        user_id = 2000
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id_2),
+                [                                      # singular events
+                    (
+                        user_id,
+                        UUID('16cfc671-5525-4a99-9eb9-4f6c074803a9').bytes,
+                        2000000000,                    # event relative timestamp (2 secs)
+                        None
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=3)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_upsert_multiple_machines', record)
+
+        # Build a request as it would have been sent to us, with a demo mode event
+        user_id = 2000
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id_2),
+                [                                      # singular events
+                    (
+                        user_id,
+                        UUID('c75af67f-cf2f-433d-a060-a670087d93a1').bytes,
+                        2000000000,                    # event relative timestamp (2 secs)
+                        None
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=3)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_upsert_multiple_machines', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            requests = dbsession.query(Request).order_by(Request.received_at).all()
+            assert len(requests) == 4
+            assert requests[0].machine_id == machine_id_1
+            assert requests[1].machine_id == machine_id_1
+            assert requests[2].machine_id == machine_id_2
+            assert requests[3].machine_id == machine_id_2
+
+            machines = dbsession.query(Machine).order_by(Machine.id).all()
+            assert len(machines) == 2
+            assert machines[0].machine_id == machine_id_1
+            assert machines[0].image_id == image_id_1
+            assert machines[0].dualboot is False
+            assert machines[0].live is True
+            assert machines[0].demo is False
+            assert machines[1].machine_id == machine_id_2
+            assert machines[1].image_id is None
+            assert machines[1].dualboot is True
+            assert machines[1].live is False
+            assert machines[1].demo is True
+
+            assert dbsession.query(DualBootBooted).count() == 1
+            assert dbsession.query(EnteredDemoMode).count() == 1
+            assert dbsession.query(ImageVersion).count() == 2
+            assert dbsession.query(LiveUsbBooted).count() == 1
 
     def test_deduplicate_dualboots(self):
         from azafea.event_processors.endless.metrics.events import DualBootBooted

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -163,8 +163,8 @@ class TestMetrics(IntegrationTest):
         from azafea.event_processors.endless.metrics.events import (
             CacheIsCorrupt, CacheMetadataIsCorrupt, ControlCenterPanelOpened, CPUInfo,
             DiscoveryFeedClicked, DiscoveryFeedClosed, DiscoveryFeedOpened, DiskSpaceExtra,
-            DiskSpaceSysroot, DualBootBooted, EndlessApplicationUnmaximized, ImageVersion,
-            LaunchedEquivalentExistingFlatpak, LaunchedEquivalentInstallerForFlatpak,
+            DiskSpaceSysroot, DualBootBooted, EndlessApplicationUnmaximized, EnteredDemoMode,
+            ImageVersion, LaunchedEquivalentExistingFlatpak, LaunchedEquivalentInstallerForFlatpak,
             LaunchedExistingFlatpak, LaunchedInstallerForFlatpak, LinuxPackageOpened, LiveUsbBooted,
             Location, LocationLabel, MissingCodec, MonitorConnected, MonitorDisconnected, NetworkId,
             OSVersion, ProgramDumpedCore, RAMSize, ShellAppAddedToDesktop,
@@ -183,8 +183,8 @@ class TestMetrics(IntegrationTest):
             Request, Machine, InvalidSingularEvent, UnknownSingularEvent,
             CacheIsCorrupt, CacheMetadataIsCorrupt, ControlCenterPanelOpened, CPUInfo,
             DiscoveryFeedClicked, DiscoveryFeedClosed, DiscoveryFeedOpened, DiskSpaceExtra,
-            DiskSpaceSysroot, DualBootBooted, EndlessApplicationUnmaximized, ImageVersion,
-            LaunchedEquivalentExistingFlatpak, LaunchedEquivalentInstallerForFlatpak,
+            DiskSpaceSysroot, DualBootBooted, EndlessApplicationUnmaximized, EnteredDemoMode,
+            ImageVersion, LaunchedEquivalentExistingFlatpak, LaunchedEquivalentInstallerForFlatpak,
             LaunchedExistingFlatpak, LaunchedInstallerForFlatpak, LinuxPackageOpened, LiveUsbBooted,
             Location, LocationLabel, MissingCodec, MonitorConnected, MonitorDisconnected, NetworkId,
             OSVersion, ProgramDumpedCore, RAMSize, ShellAppAddedToDesktop,
@@ -281,6 +281,12 @@ class TestMetrics(IntegrationTest):
                         UUID('2b5c044d-d819-4e2c-a3a6-c485c1ac371e').bytes,
                         32000000000,                   # event relative timestamp (32 secs)
                         GLib.Variant('s', 'org.gnome.Calendar')
+                    ),
+                    (
+                        user_id,
+                        UUID('c75af67f-cf2f-433d-a060-a670087d93a1').bytes,
+                        36000000000,                   # event relative timestamp (36 secs)
+                        None
                     ),
                     (
                         user_id,
@@ -571,6 +577,11 @@ class TestMetrics(IntegrationTest):
             assert unmaximized.user_id == user_id
             assert unmaximized.occured_at == now - timedelta(seconds=2) + timedelta(seconds=32)
             assert unmaximized.app_id == 'org.gnome.Calendar'
+
+            demo = dbsession.query(EnteredDemoMode).one()
+            assert demo.request_id == request.id
+            assert demo.user_id == user_id
+            assert demo.occured_at == now - timedelta(seconds=2) + timedelta(seconds=36)
 
             image = dbsession.query(ImageVersion).one()
             assert image.request_id == request.id

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -867,6 +867,7 @@ class TestMetrics(IntegrationTest):
             machine = dbsession.query(Machine).one()
             assert machine.machine_id == request.machine_id
             assert machine.image_id == image_id
+            assert machine.dualboot is False
 
     def test_insert_machine_invalid_image_id(self, capfd):
         from azafea.event_processors.endless.metrics.events import ImageVersion
@@ -924,6 +925,64 @@ class TestMetrics(IntegrationTest):
 
         capture = capfd.readouterr()
         assert f'Invalid image id {image_id!r}: Did not match the expected format' in capture.err
+
+    def test_insert_machine_dualboot(self):
+        from azafea.event_processors.endless.metrics.events import DualBootBooted
+        from azafea.event_processors.endless.metrics.machine import Machine
+        from azafea.event_processors.endless.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request, Machine, DualBootBooted)
+
+        # Build a request as it would have been sent to us
+        now = datetime.now(tz=timezone.utc)
+        machine_id = 'ffffffffffffffffffffffffffffffff'
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id),
+                [                                      # singular events
+                    (
+                        1001,
+                        UUID('16cfc671-5525-4a99-9eb9-4f6c074803a9').bytes,
+                        2000000000,                    # event relative timestamp (2 secs)
+                        None
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_insert_machine_dualboot', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).one()
+
+            dualboot = dbsession.query(DualBootBooted).one()
+            assert dualboot.request_id == request.id
+
+            machine = dbsession.query(Machine).one()
+            assert machine.machine_id == request.machine_id
+            assert machine.image_id is None
+            assert machine.dualboot is True
 
     def test_multiple_machines(self):
         from azafea.event_processors.endless.metrics.events import ImageVersion

--- a/azafea/event_processors/endless/metrics/tests/test_events.py
+++ b/azafea/event_processors/endless/metrics/tests/test_events.py
@@ -190,6 +190,7 @@ def test_new_unknown_event():
         GLib.Variant('s', 'org.gnome.Calendar'),
         {'app_id': 'org.gnome.Calendar'}
     ),
+    ('EnteredDemoMode', None, {}),
     (
         'HackClubhouseAchievement',
         GLib.Variant('(ss)', ('id', 'name')),

--- a/azafea/event_processors/endless/metrics/v2/cli.py
+++ b/azafea/event_processors/endless/metrics/v2/cli.py
@@ -39,7 +39,7 @@ from ..events import (
     sequence_is_known,
     singular_event_is_known,
 )
-from ..machine import Machine, upsert_machine_image
+from ..machine import Machine, upsert_machine_dualboot, upsert_machine_image
 from ..request import Request
 
 
@@ -81,6 +81,14 @@ def register_commands(subs: argparse._SubParsersAction) -> None:
     parse_images.add_argument('--chunk-size', type=int, default=5000,
                               help='The size of the chunks to operate on')
     parse_images.set_defaults(subcommand=do_parse_images)
+
+    replay_machine_dualboots = subs.add_parser(
+        'replay-machine-dual-boots',
+        help='Replay "dual boot" events to populate the machine mapping table',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    replay_machine_dualboots.add_argument('--chunk-size', type=int, default=5000,
+                                          help='The size of the chunks to operate on')
+    replay_machine_dualboots.set_defaults(subcommand=do_replay_machine_dualboots)
 
     replay_machine_images = subs.add_parser('replay-machine-images',
                                             help='Replay "image version" events to populate the '
@@ -336,6 +344,27 @@ def do_replay_invalid(config: Config, args: argparse.Namespace) -> None:
             progress(chunk_number * args.chunk_size, total)
 
     progress(total, total, end='\n')
+
+
+def do_replay_machine_dualboots(config: Config, args: argparse.Namespace) -> None:
+    db = Db(config.postgresql)
+    log.info('Replaying the dual boot events…')
+
+    with db as dbsession:
+        query = dbsession.query(Request.machine_id)
+        query = query.join(DualBootBooted)
+        query = query.distinct()
+
+        total = query.count()
+
+        for i, (machine_id, ) in enumerate(query, start=1):
+            upsert_machine_dualboot(dbsession, machine_id)
+
+            if (i % args.chunk_size) == 0:
+                dbsession.commit()
+                progress(i, total)
+
+        progress(total, total)
 
 
 def do_replay_machine_images(config: Config, args: argparse.Namespace) -> None:

--- a/azafea/event_processors/endless/metrics/v2/cli.py
+++ b/azafea/event_processors/endless/metrics/v2/cli.py
@@ -39,7 +39,7 @@ from ..events import (
     sequence_is_known,
     singular_event_is_known,
 )
-from ..machine import Machine, insert_machine
+from ..machine import Machine, upsert_machine_image
 from ..request import Request
 
 
@@ -350,7 +350,7 @@ def do_replay_machine_images(config: Config, args: argparse.Namespace) -> None:
         total = query.count()
 
         for i, (machine_id, image_id) in enumerate(query, start=1):
-            insert_machine(dbsession, machine_id, image_id)
+            upsert_machine_image(dbsession, machine_id, image_id)
 
             if (i % args.chunk_size) == 0:
                 dbsession.commit()

--- a/azafea/event_processors/endless/metrics/v2/migrations/a6e10c2e3f79_add_a_demo_property_to_the_machine.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/a6e10c2e3f79_add_a_demo_property_to_the_machine.py
@@ -1,0 +1,27 @@
+# type: ignore
+
+"""Add a demo property to the machine
+
+Revision ID: a6e10c2e3f79
+Revises: b3ad0a81aa3c
+Create Date: 2020-02-24 14:01:11.715316
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a6e10c2e3f79'
+down_revision = 'b3ad0a81aa3c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('metrics_machine', sa.Column('demo', sa.Boolean(), nullable=True,
+                                               server_default=sa.sql.expression.false()))
+
+
+def downgrade():
+    op.drop_column('metrics_machine', 'demo')

--- a/azafea/event_processors/endless/metrics/v2/migrations/b3ad0a81aa3c_add_the_demo_mode_event.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/b3ad0a81aa3c_add_the_demo_mode_event.py
@@ -1,0 +1,38 @@
+# type: ignore
+
+"""Add the demo mode event
+
+Revision ID: b3ad0a81aa3c
+Revises: d99f33473540
+Create Date: 2020-02-24 13:08:11.496377
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b3ad0a81aa3c'
+down_revision = 'd99f33473540'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('entered_demo_mode',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', sa.BigInteger(), nullable=False),
+                    sa.Column('occured_at', sa.DateTime(timezone=True), nullable=False),
+                    sa.Column('request_id', sa.Integer(), nullable=True),
+                    sa.ForeignKeyConstraint(
+                        ['request_id'], ['metrics_request_v2.id'],
+                        name=op.f('fk_entered_demo_mode_request_id_metrics_request_v2')),
+                    sa.PrimaryKeyConstraint('id', name=op.f('pk_entered_demo_mode'))
+                    )
+    op.create_index(op.f('ix_entered_demo_mode_request_id'), 'entered_demo_mode', ['request_id'],
+                    unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_entered_demo_mode_request_id'), table_name='entered_demo_mode')
+    op.drop_table('entered_demo_mode')

--- a/azafea/event_processors/endless/metrics/v2/migrations/b4cf8c78ca97_make_the_machine_s_image_id_optional.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/b4cf8c78ca97_make_the_machine_s_image_id_optional.py
@@ -1,0 +1,26 @@
+# type: ignore
+
+"""Make the machine's image id optional
+
+Revision ID: b4cf8c78ca97
+Revises: 3dc06459fc41
+Create Date: 2020-02-19 10:00:46.948624
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b4cf8c78ca97'
+down_revision = '3dc06459fc41'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('metrics_machine', 'image_id', existing_type=sa.VARCHAR(), nullable=True)
+
+
+def downgrade():
+    op.alter_column('metrics_machine', 'image_id', existing_type=sa.VARCHAR(), nullable=False)

--- a/azafea/event_processors/endless/metrics/v2/migrations/cced14e41a46_add_a_dualboot_property_to_the_machine.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/cced14e41a46_add_a_dualboot_property_to_the_machine.py
@@ -1,0 +1,27 @@
+# type: ignore
+
+"""Add a dualboot property to the machine
+
+Revision ID: cced14e41a46
+Revises: b4cf8c78ca97
+Create Date: 2020-02-19 10:44:24.683813
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'cced14e41a46'
+down_revision = 'b4cf8c78ca97'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('metrics_machine', sa.Column('dualboot', sa.Boolean(), nullable=True,
+                                               server_default=sa.sql.expression.false()))
+
+
+def downgrade():
+    op.drop_column('metrics_machine', 'dualboot')

--- a/azafea/event_processors/endless/metrics/v2/migrations/d99f33473540_add_a_live_property_to_the_machine.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/d99f33473540_add_a_live_property_to_the_machine.py
@@ -1,0 +1,27 @@
+# type: ignore
+
+"""Add a live property to the machine
+
+Revision ID: d99f33473540
+Revises: cced14e41a46
+Create Date: 2020-02-19 10:56:19.364093
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd99f33473540'
+down_revision = 'cced14e41a46'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('metrics_machine', sa.Column('live', sa.Boolean(), nullable=True,
+                                               server_default=sa.sql.expression.false()))
+
+
+def downgrade():
+    op.drop_column('metrics_machine', 'live')


### PR DESCRIPTION
That's really what they are, since they can't be changed, and they probably could have been sent by clients as request attributes rather than events.

But things are what they are, and we get them as events.

However we can still do better on the server side, by storing them as columns in the machine table, making queries much easier.

This change adds the columns, and populates them for incoming records. Commands to replay old events are also included.