### PR TITLE
Deduplicate dualboot and live USB events

### DIFF
--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -690,7 +690,7 @@ class UserIsLoggedIn(SequenceEvent):
 
 @listens_for(DbSession, 'after_attach')
 def receive_after_attach(dbsession: DbSession, instance: Base) -> None:
-    if not isinstance(instance, (DualBootBooted, ImageVersion)):
+    if not isinstance(instance, (DualBootBooted, ImageVersion, LiveUsbBooted)):
         return
 
     # So we have just added an event to the session, but we only want to keep it if there

--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -7,8 +7,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-from operator import attrgetter
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from gi.repository import GLib
 
@@ -694,28 +693,20 @@ def receive_after_attach(dbsession: DbSession, instance: Base) -> None:
     if not isinstance(instance, ImageVersion):
         return
 
-    # So we have just added an ImageVersion to the session, let's only keep one new (pending)
+    # So we have just added an ImageVersion to the session, but we only want to keep it if there
+    # wasn't already a pending one for the same metrics request
+
     all_image_versions = (x for x in dbsession.new if isinstance(x, ImageVersion))
     all_image_versions = (x for x in all_image_versions if inspect(x).pending)
-
-    image_versions_per_request: Dict[str, List[ImageVersion]] = {}
-
-    for image_version in all_image_versions:
+    image_versions_in_this_request = [
         # Requests don't have an id yet, because they have just been added to the db session which
         # hasn't been committed yet; their sha512 is a good replacement identifier given that we
         # have a unicity constraint on them
-        request_id = image_version.request.sha512
+        x for x in all_image_versions if x.request.sha512 == instance.request.sha512
+    ]
 
-        image_versions_per_request.setdefault(request_id, [])
-        image_versions_per_request[request_id].append(image_version)
-        image_versions_per_request[request_id].sort(key=attrgetter('occured_at'))
-
-    for _request_id, image_versions in image_versions_per_request.items():
-        # Keep only the first image version for each request
-        to_expunge = image_versions[1:]
-
-        for image_version in to_expunge:
-            dbsession.expunge(image_version)
+    if len(image_versions_in_this_request) > 1:
+        dbsession.expunge(instance)
 
 
 @listens_for(DbSession, 'before_commit')

--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -690,7 +690,7 @@ class UserIsLoggedIn(SequenceEvent):
 
 @listens_for(DbSession, 'after_attach')
 def receive_after_attach(dbsession: DbSession, instance: Base) -> None:
-    if not isinstance(instance, ImageVersion):
+    if not isinstance(instance, (DualBootBooted, ImageVersion)):
         return
 
     # So we have just added an event to the session, but we only want to keep it if there

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
@@ -18,6 +18,72 @@ from azafea.vendors import normalize_vendor
 class TestMetrics(IntegrationTest):
     handler_module = 'azafea.event_processors.endless.metrics.v2'
 
+    def test_dedupe_no_dualboots(self, capfd):
+        from azafea.event_processors.endless.metrics.events import DualBootBooted
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(DualBootBooted)
+
+        with self.db as dbsession:
+            assert dbsession.query(DualBootBooted).count() == 0
+
+        self.run_subcommand('test_dedupe_no_dualboots', 'dedupe-dual-boots')
+
+        with self.db as dbsession:
+            assert dbsession.query(DualBootBooted).count() == 0
+
+        capture = capfd.readouterr()
+        assert 'No metrics requests with deduplicate dual boot events found' in capture.out
+
+    def test_dedupe_dualboots(self):
+        from azafea.event_processors.endless.metrics.events import DualBootBooted
+        from azafea.event_processors.endless.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request, DualBootBooted)
+
+        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        with self.db as dbsession:
+            dbsession.add(Request(serialized=b'whatever', sha512='sha512-1', received_at=occured_at,
+                                  absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
+                                  send_number=0))
+            dbsession.add(Request(serialized=b'whatever', sha512='sha512-2', received_at=occured_at,
+                                  absolute_timestamp=3, relative_timestamp=4, machine_id='machine2',
+                                  send_number=0))
+            dbsession.add(Request(serialized=b'whatever', sha512='sha512-3', received_at=occured_at,
+                                  absolute_timestamp=5, relative_timestamp=6, machine_id='machine3',
+                                  send_number=0))
+
+        # Insert multiple dual boot events.
+        #
+        # We have to do it this way because adding them all in the same session would get them
+        # deduplicated before we ever had a chance to run the command.
+
+        for i in range(9):
+            with self.db as dbsession:
+                request = dbsession.query(Request).order_by(Request.id).all()[i % 3]
+                dbsession.add(DualBootBooted(request=request, user_id=i, occured_at=occured_at,
+                                             payload=GLib.Variant('mv', None)))
+
+        with self.db as dbsession:
+            req1, req2, req3 = dbsession.query(Request).order_by(Request.id).all()
+            assert dbsession.query(DualBootBooted).filter_by(request_id=req1.id).count() == 3
+            assert dbsession.query(DualBootBooted).filter_by(request_id=req2.id).count() == 3
+            assert dbsession.query(DualBootBooted).filter_by(request_id=req3.id).count() == 3
+
+        # Run the deduplication
+        self.run_subcommand('test_dedupe_dualboots', 'dedupe-dual-boots', '--chunk-size=5')
+
+        # Verify again after the deduplication
+        with self.db as dbsession:
+            req1, req2, req3 = dbsession.query(Request).order_by(Request.id).all()
+            assert dbsession.query(DualBootBooted).filter_by(request_id=req1.id).one().user_id == 0
+            assert dbsession.query(DualBootBooted).filter_by(request_id=req2.id).one().user_id == 1
+            assert dbsession.query(DualBootBooted).filter_by(request_id=req3.id).one().user_id == 2
+
     def test_dedupe_no_image_versions(self, capfd):
         from azafea.event_processors.endless.metrics.events import ImageVersion
 

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -1051,7 +1051,7 @@ class TestMetrics(IntegrationTest):
             assert dbsession.query(Machine).order_by(Machine.id).count() == 2
             assert dbsession.query(ImageVersion).order_by(ImageVersion.id).count() == 3
 
-    def test_multiple_image_versions_in_a_request(self):
+    def test_deduplicate_image_versions(self):
         from azafea.event_processors.endless.metrics.events import ImageVersion
         from azafea.event_processors.endless.metrics.request import Request
 
@@ -1098,7 +1098,7 @@ class TestMetrics(IntegrationTest):
         record = received_at_timestamp_bytes + request_body
 
         # Send the event request to the Redis queue
-        self.redis.lpush('test_multiple_image_versions_in_a_request', record)
+        self.redis.lpush('test_deduplicate_image_versions', record)
 
         # Run Azafea so it processes the event
         self.run_azafea()

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -1226,7 +1226,7 @@ class TestMetrics(IntegrationTest):
             live = dbsession.query(LiveUsbBooted).one()
             assert live.user_id == 1001
 
-    def test_deduplicate_image_versions_per_request(self):
+    def test_deduplicate_multiple_events_per_request(self):
         # This test is a bit different from the others, because it does not push a request to Redis
         # for Azafea to process, it operates directly on the model.
         #
@@ -1234,42 +1234,66 @@ class TestMetrics(IntegrationTest):
         # requests in a single database transaction, but Azafea (currently) always opens a new
         # database transaction for each request.
 
-        from azafea.event_processors.endless.metrics.events import ImageVersion
+        from azafea.event_processors.endless.metrics.events import (
+            DualBootBooted, ImageVersion, LiveUsbBooted)
         from azafea.event_processors.endless.metrics.request import Request
 
         self.run_subcommand('initdb')
-        self.ensure_tables(ImageVersion, Request)
+        self.ensure_tables(Request, DualBootBooted, ImageVersion, LiveUsbBooted)
 
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
 
         with self.db as dbsession:
-            # Add a first request with 2 image version events
+            # Add a first request with 1 dualboot, 2 image version and 3 live usb events
             request = Request(serialized=b'whatever', sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine1',
                               send_number=0)
             dbsession.add(request)
 
             image_id_1 = 'eos-eos3.6-amd64-amd64.190619-225606.base'
+            dbsession.add(DualBootBooted(request=request, user_id=1001, occured_at=occured_at,
+                                         payload=GLib.Variant('mv', None)))
             dbsession.add(ImageVersion(request=request, user_id=1001, occured_at=occured_at,
                                        payload=GLib.Variant('mv', GLib.Variant('s', image_id_1))))
             dbsession.add(ImageVersion(request=request, user_id=1002, occured_at=occured_at,
                                        payload=GLib.Variant('mv', GLib.Variant('s', image_id_1))))
+            dbsession.add(LiveUsbBooted(request=request, user_id=1001, occured_at=occured_at,
+                                        payload=GLib.Variant('mv', None)))
+            dbsession.add(LiveUsbBooted(request=request, user_id=1002, occured_at=occured_at,
+                                        payload=GLib.Variant('mv', None)))
+            dbsession.add(LiveUsbBooted(request=request, user_id=1003, occured_at=occured_at,
+                                        payload=GLib.Variant('mv', None)))
 
-            # Add a second request with 2 image version events
+            # Add a second request with 1 dualboot, 2 image version and 3 live usb events
             request = Request(serialized=b'whatever2', sha512='whatever2', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='machine2',
                               send_number=0)
             dbsession.add(request)
 
             image_id_2 = 'eos-eos3.7-amd64-amd64.191019-225606.base'
+            dbsession.add(DualBootBooted(request=request, user_id=2001, occured_at=occured_at,
+                                         payload=GLib.Variant('mv', None)))
             dbsession.add(ImageVersion(request=request, user_id=2001, occured_at=occured_at,
                                        payload=GLib.Variant('mv', GLib.Variant('s', image_id_2))))
             dbsession.add(ImageVersion(request=request, user_id=2002, occured_at=occured_at,
                                        payload=GLib.Variant('mv', GLib.Variant('s', image_id_2))))
+            dbsession.add(LiveUsbBooted(request=request, user_id=2001, occured_at=occured_at,
+                                        payload=GLib.Variant('mv', None)))
+            dbsession.add(LiveUsbBooted(request=request, user_id=2002, occured_at=occured_at,
+                                        payload=GLib.Variant('mv', None)))
+            dbsession.add(LiveUsbBooted(request=request, user_id=2003, occured_at=occured_at,
+                                        payload=GLib.Variant('mv', None)))
 
         with self.db as dbsession:
             requests = dbsession.query(Request).order_by(Request.id).all()
             assert len(requests) == 2
+
+            dualboots = dbsession.query(DualBootBooted).order_by(DualBootBooted.request_id).all()
+            assert len(dualboots) == 2
+            assert dualboots[0].request_id == requests[0].id
+            assert dualboots[0].user_id == 1001
+            assert dualboots[1].request_id == requests[1].id
+            assert dualboots[1].user_id == 2001
 
             images = dbsession.query(ImageVersion).order_by(ImageVersion.request_id).all()
             assert len(images) == 2
@@ -1279,6 +1303,13 @@ class TestMetrics(IntegrationTest):
             assert images[1].image_id == image_id_2
             assert images[1].request_id == requests[1].id
             assert images[1].user_id == 2001
+
+            live_usbs = dbsession.query(LiveUsbBooted).order_by(LiveUsbBooted.request_id).all()
+            assert len(live_usbs) == 2
+            assert live_usbs[0].request_id == requests[0].id
+            assert live_usbs[0].user_id == 1001
+            assert live_usbs[1].request_id == requests[1].id
+            assert live_usbs[1].user_id == 2001
 
     def test_unknown_singular_events(self):
         from azafea.event_processors.endless.metrics.events._base import UnknownSingularEvent


### PR DESCRIPTION
Much like the image version events, those are only interesting to get once.

Deduplicating them entirely might be a bit hard, coordinating between multiple processes, but we can easily deduplicate them per request.

This does that for incoming events, and adds a command to go over the old events and deduplicate them after the fact.