### PR TITLE
T28742 Parental controls migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist/
 /docs/build/
 __pycache__/
+config.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,34 @@ You can simply clone the Git repository:
 $ git clone https://github.com/endlessm/azafea
 ```
 
-At this point you will want to build the container image you will work from:
+At this point you will want to build the container image you will work from.
+If you are planning on [adding a new event](azafea/event_processors/endless/metrics/new-event.rst)
+you should create a `config.toml` file in the source root of the project before
+running this command.
 
 ```
+$ cat config.toml
+[main]
+verbose = false
+number_of_workers = 8
+exit_on_empty_queues = false
+
+[redis]
+host = "localhost"
+port = 6379
+password = "** hidden **"
+
+[postgresql]
+host = "localhost"
+port = 5432
+user = "azafea"
+password = "** hidden **"
+database = "azafea"
+
+[queues.metrics]
+handler = "azafea.event_processors.endless.metrics.v2"
+
+[postgresql.connect_args]
 $ sudo docker build --rm --build-arg build_type=dev --tag azafea-dev .
 ```
 

--- a/azafea/event_processors/endless/metrics/new-event.rst
+++ b/azafea/event_processors/endless/metrics/new-event.rst
@@ -68,7 +68,10 @@ Creating the tables
 
 After adding a new model, stop Azafea and create the database migration::
 
-    [azafea-dev]$ pipenv run azafea -c config.toml make-migrations
+    [azafea-dev]$ pipenv run azafea -c config.toml make-migration queue-name
+
+The queue-name is the configured name of a :ref:`queue <queue-config>` set up
+with the handler which contains the new model.
 
 Carefully review the generated migration file, and commit it along with your
 new event.

--- a/azafea/event_processors/endless/metrics/v2/migrations/9bd33e9778fa_add_parental_controls_events.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/9bd33e9778fa_add_parental_controls_events.py
@@ -1,0 +1,111 @@
+# type: ignore
+
+"""Add parental controls events
+
+Revision ID: 9bd33e9778fa
+Revises: a6e10c2e3f79
+Create Date: 2020-04-21 11:09:12.496378
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '9bd33e9778fa'
+down_revision = 'a6e10c2e3f79'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('parental_controls_blocked_flatpak_install',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', sa.BigInteger(), nullable=False),
+                    sa.Column('occured_at', sa.DateTime(timezone=True), nullable=False),
+                    sa.Column('app', sa.Unicode(), nullable=False),
+                    sa.Column('request_id', sa.Integer(), nullable=True),
+                    sa.ForeignKeyConstraint(
+                        ['request_id'], ['metrics_request_v2.id'],
+                        name=op.f(
+                            'fk_parental_controls_blocked_flatpak_install_'
+                            'request_id_metrics_request_v2'
+                        )),
+                    sa.PrimaryKeyConstraint(
+                        'id',
+                        name=op.f('pk_parental_controls_blocked_flatpak_install')))
+    op.create_index(op.f('ix_parental_controls_blocked_flatpak_install_request_id'),
+                    'parental_controls_blocked_flatpak_install', ['request_id'], unique=False)
+
+    op.create_table('parental_controls_blocked_flatpak_run',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', sa.BigInteger(), nullable=False),
+                    sa.Column('occured_at', sa.DateTime(timezone=True), nullable=False),
+                    sa.Column('app', sa.Unicode(), nullable=False),
+                    sa.Column('request_id', sa.Integer(), nullable=True),
+                    sa.ForeignKeyConstraint(
+                        ['request_id'], ['metrics_request_v2.id'],
+                        name=op.f(
+                            'fk_parental_controls_blocked_flatpak_run_request_id_metrics_request_v2'
+                        )),
+                    sa.PrimaryKeyConstraint(
+                        'id',
+                        name=op.f('pk_parental_controls_blocked_flatpak_run')))
+    op.create_index(op.f('ix_parental_controls_blocked_flatpak_run_request_id'),
+                    'parental_controls_blocked_flatpak_run', ['request_id'], unique=False)
+
+    op.create_table('parental_controls_changed',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', sa.BigInteger(), nullable=False),
+                    sa.Column('occured_at', sa.DateTime(timezone=True), nullable=False),
+                    sa.Column('app_filter_is_whitelist', sa.Boolean(), nullable=False),
+                    sa.Column('app_filter', sa.ARRAY(sa.Unicode(), dimensions=1), nullable=False),
+                    sa.Column('oars_filter',
+                              postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+                    sa.Column('allow_user_installation', sa.Boolean(), nullable=False),
+                    sa.Column('allow_system_installation', sa.Boolean(), nullable=False),
+                    sa.Column('is_administrator', sa.Boolean(), nullable=False),
+                    sa.Column('is_initial_setup', sa.Boolean(), nullable=False),
+                    sa.Column('request_id', sa.Integer(), nullable=True),
+                    sa.ForeignKeyConstraint(
+                        ['request_id'], ['metrics_request_v2.id'],
+                        name=op.f(
+                            'fk_parental_controls_changed_request_id_metrics_request_v2'
+                        )),
+                    sa.PrimaryKeyConstraint('id', name=op.f('pk_parental_controls_changed')))
+    op.create_index(op.f('ix_parental_controls_changed_request_id'),
+                    'parental_controls_changed', ['request_id'], unique=False)
+
+    op.create_table('parental_controls_enabled',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', sa.BigInteger(), nullable=False),
+                    sa.Column('occured_at', sa.DateTime(timezone=True), nullable=False),
+                    sa.Column('enabled', sa.Boolean(), nullable=False),
+                    sa.Column('request_id', sa.Integer(), nullable=True),
+                    sa.ForeignKeyConstraint(
+                        ['request_id'], ['metrics_request_v2.id'],
+                        name=op.f(
+                            'fk_parental_controls_enabled_request_id_metrics_request_v2'
+                        )),
+                    sa.PrimaryKeyConstraint('id', name=op.f('pk_parental_controls_enabled')))
+    op.create_index(op.f('ix_parental_controls_enabled_request_id'),
+                    'parental_controls_enabled', ['request_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_parental_controls_blocked_flatpak_install_request_id'),
+                  table_name='parental_controls_blocked_flatpak_install')
+    op.drop_table('parental_controls_blocked_flatpak_install')
+
+    op.drop_index(op.f('ix_parental_controls_blocked_flatpak_run_request_id'),
+                  table_name='parental_controls_blocked_flatpak_run')
+    op.drop_table('parental_controls_blocked_flatpak_run')
+
+    op.drop_index(op.f('ix_parental_controls_changed_request_id'),
+                  table_name='parental_controls_changed')
+    op.drop_table('parental_controls_changed')
+
+    op.drop_index(op.f('ix_parental_controls_enabled_request_id'),
+                  table_name='parental_controls_enabled')
+    op.drop_table('parental_controls_enabled')

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -54,10 +54,10 @@ Azafea requires PostgreSQL 11 or later. Installing it with Docker is simply::
 Before running PostgreSQL, you need to choose a directory in which to store the
 database files.
 
-In this example we will use ``/var/lib/pgsql/azafea/data``, so let's create
+In this example we will use ``/var/lib/postgresql/azafea/data``, so let's create
 it::
 
-    $ sudo mkdir -p /var/lib/pgsql/azafea/data
+    $ sudo mkdir -p /var/lib/postgresql/azafea/data
 
 We can now run PostgreSQL, telling it to use that directory::
 


### PR DESCRIPTION
This adds the missing database migration script for the new parental controls events, which I neglected to add in the initial commit.

I haven’t tested this, since setting up postgresql and redis containers in order to do so is a fairly involved effort. We’ll see if it works when doing the test database migrationm

https://phabricator.endlessm.com/T28742