### PR TITLE
Use the same Dockerfile as we use in production.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 - docker
 
 install:
-- docker build --build-arg build_type=dev --tag azafea-tests .
+- docker build --tag azafea-tests .
 
 matrix:
   include:

--- a/config.toml.j2
+++ b/config.toml.j2
@@ -1,0 +1,24 @@
+[main]
+verbose = {{ VERBOSE }}
+number_of_workers = {{ NUM_OF_WORKERS }}
+
+[redis]
+host = "{{ REDIS_HOST }}"
+password = "{{ REDIS_PASSWORD }}"
+
+[postgresql]
+host = "{{ POSTGRES_HOST }}"
+password = "{{ POSTGRES_PASSWORD }}"
+
+[queues.activation-1]
+handler = "azafea.event_processors.endless.activation.v1"
+
+[queues.ping-1]
+handler = "azafea.event_processors.endless.ping.v1"
+
+[queues.metrics-2]
+handler = "azafea.event_processors.endless.metrics.v2"
+
+[postgresql.connect_args]
+sslmode = "verify-full"
+sslrootcert = "/etc/ssl/certs/ca-certificates.crt"

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eux
+
+template config.toml.j2 -o /tmp/config.toml
+eval exec "$@"


### PR DESCRIPTION
In production in Endless, we use a different Dockerfile with a slightly
different setup. The main points are using the Alpine variant of the
Python base image and rendering a `config.toml` file from a template and
environment variable. This commit uses (almost) exactly the same
Dockerfile that we use in production since Azafea was deployed and it
can be argued that it's the most tested one. We don't have a dev/ prod
image so that build argument is dropped.