### PR TITLE
Improve shell_app_is_open to allow easier and faster reports

### DIFF
--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -14,7 +14,7 @@ from gi.repository import GLib
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, JSONB
 from sqlalchemy.event import listens_for
 from sqlalchemy.inspection import inspect
-from sqlalchemy.schema import Column
+from sqlalchemy.schema import Column, Index
 from sqlalchemy.types import ARRAY, BigInteger, Boolean, Integer, LargeBinary, Numeric, Unicode
 
 from azafea.model import Base, DbSession
@@ -790,6 +790,11 @@ class ShellAppIsOpen(SequenceEvent):
     __payload_type__ = 's'
 
     app_id = Column(Unicode, nullable=False)
+
+    __table_args__ = (
+        Index('ix_shell_app_is_open_app_id_started_at', 'started_at', 'app_id',
+              postgresql_ops={'app_id': 'varchar_pattern_ops'}),
+    )
 
     @staticmethod
     def _get_fields_from_payload(payload: GLib.Variant) -> Dict[str, Any]:

--- a/azafea/event_processors/endless/metrics/v2/migrations/4a49897b47ea_open_app_id_started_at_index.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/4a49897b47ea_open_app_id_started_at_index.py
@@ -1,0 +1,31 @@
+# type: ignore
+
+"""Add an index to find the most used apps faster
+
+Revision ID: 4a49897b47ea
+Revises: 9bd33e9778fa
+Create Date: 2020-04-30 12:39:16.338295
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '4a49897b47ea'
+down_revision = '9bd33e9778fa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        'ix_shell_app_is_open_app_id_started_at',
+        'shell_app_is_open',
+        ['started_at', 'app_id'],
+        unique=False,
+        postgresql_ops={'app_id': 'varchar_pattern_ops'},
+    )
+
+
+def downgrade():
+    op.drop_index('ix_shell_app_is_open_app_id_started_at', table_name='shell_app_is_open')

--- a/azafea/event_processors/endless/metrics/v2/migrations/d4809698244a_add_duration.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/d4809698244a_add_duration.py
@@ -1,0 +1,28 @@
+# type: ignore
+
+"""Add duration column to open shell apps
+
+Revision ID: d4809698244a
+Revises: 4a49897b47ea
+Create Date: 2020-04-30 13:54:30.888222
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd4809698244a'
+down_revision = '4a49897b47ea'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('shell_app_is_open', sa.Column('duration', sa.Float(), nullable=True))
+    op.execute('UPDATE shell_app_is_open SET duration = 0')
+    op.alter_column('shell_app_is_open', 'duration', nullable=False)
+
+
+def downgrade():
+    op.drop_column('shell_app_is_open', 'duration')


### PR DESCRIPTION
This PR brings two improvements:
- Add an index to improve speed when we want to retrieve data involving start
time and group it by app ID (7086bbf).
- Add a `duration` column allowing Metabase users to query duration with no SQL (0c2f39c).

`duration` is a float representing difference between `stopped_at` and `started_at` in seconds. It’s implemented as a SQLAlchemy default value, as the lines are not supposed to be changed.

https://phabricator.endlessm.com/T29220