### PR TITLE
Configure flake8 outside of pytest configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,8 +50,10 @@ warn_unused_ignores = True
 [mypy-azafea.tests.*,azafea.event_processors.*.tests.*]
 disallow_untyped_defs = False
 
+[flake8]
+max-line-length = 100
+
 [tool:pytest]
-flake8-max-line-length = 100
 filterwarnings =
     error::DeprecationWarning:azafea.*
     ignore::DeprecationWarning:distutils.*


### PR DESCRIPTION
Configuring flake8 in its own section gives the opportunity to third-party tools to use this configuration too. It can, for example, be useful for text editors with embedded linters.

Of course, it works with pytest too.