### PR TITLE
Strip useless quotes and field from OS information

### DIFF
--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -560,8 +560,8 @@ class OSVersion(SingularEvent):
     @staticmethod
     def _get_fields_from_payload(payload: GLib.Variant) -> Dict[str, Any]:
         return {
-            'name': payload.get_child_value(0).get_string(),
-            'version': payload.get_child_value(1).get_string(),
+            'name': payload.get_child_value(0).get_string().strip('"'),
+            'version': payload.get_child_value(1).get_string().strip('"'),
         }
 
 

--- a/azafea/event_processors/endless/metrics/tests/test_events.py
+++ b/azafea/event_processors/endless/metrics/tests/test_events.py
@@ -341,6 +341,11 @@ def test_new_unknown_event():
         {'name': 'Endless', 'version': '3.5.3'}
     ),
     (
+        'OSVersion',
+        GLib.Variant('(sss)', ('"Endless"', '"3.5.3"', 'obsolete and ignored')),
+        {'name': 'Endless', 'version': '3.5.3'}
+    ),
+    (
         'ParentalControlsBlockedFlatpakInstall',
         GLib.Variant('s', 'com.realm667.WolfenDoom_Blade_of_Agony'),
         {'app': 'com.realm667.WolfenDoom_Blade_of_Agony'}


### PR DESCRIPTION
OS information fields get useless extra quotes and field in the payload.

This pull request:
- ~~drops the useless `name` column,~~
- strips the useless quotes around `version` (and `name`) before inserting new rows,
- adds a command removing useless quotes from `version` (and `name`) in database.

~~This is a draft because:~~
- ~~it needs endlessm/eos-metrics-instrumentation#88 (draft too),~~
- ~~it includes an Alembic migration and thus has to be adjusted when #109 is merged.~~

https://phabricator.endlessm.com/T29322