### PR TITLE
Drop the OS name column

### DIFF
--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -551,16 +551,14 @@ class OSVersion(SingularEvent):
     __tablename__ = 'os_version'
     __event_uuid__ = '1fa16a31-9225-467e-8502-e31806e9b4eb'
 
-    # The 3rd field is now obsolete and ignored, so we only parse and store the first 2
+    # The 1st and 3rd fields are now obsolete and ignored, so we only parse and store the 2nd one
     __payload_type__ = '(sss)'
 
-    name = Column(Unicode, nullable=False)
     version = Column(Unicode, nullable=False)
 
     @staticmethod
     def _get_fields_from_payload(payload: GLib.Variant) -> Dict[str, Any]:
         return {
-            'name': payload.get_child_value(0).get_string().strip('"'),
             'version': payload.get_child_value(1).get_string().strip('"'),
         }
 

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
@@ -1016,23 +1016,19 @@ class TestMetrics(IntegrationTest):
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         with self.db as dbsession:
             version = OSVersion(
-                name='"Endless"', version='"1.2.3"', user_id=1, payload=payload,
-                occured_at=occured_at)
+                version='"1.2.3"', user_id=1, payload=payload, occured_at=occured_at)
             # Bypass quotes removed by _get_fields_from_payload
-            version.name = '"Endless"'
             version.version = '"1.2.3"'
             dbsession.add(version)
 
         with self.db as dbsession:
             version = dbsession.query(OSVersion).one()
-            assert version.name == '"Endless"'
             assert version.version == '"1.2.3"'
 
         self.run_subcommand('test_remove_os_info_quotes', 'remove-os-info-quotes')
 
         with self.db as dbsession:
             version = dbsession.query(OSVersion).one()
-            assert version.name == 'Endless'
             assert version.version == '1.2.3'
 
     def test_remove_os_info_no_quotes(self, capfd):
@@ -1046,14 +1042,12 @@ class TestMetrics(IntegrationTest):
         occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
         with self.db as dbsession:
             dbsession.add(OSVersion(
-                name='Endless', version='1.2.3', user_id=1, occured_at=occured_at,
-                payload=payload))
+                version='1.2.3', user_id=1, occured_at=occured_at, payload=payload))
 
         self.run_subcommand('test_remove_os_info_no_quotes', 'remove-os-info-quotes')
 
         with self.db as dbsession:
             version = dbsession.query(OSVersion).one()
-            assert version.name == 'Endless'
             assert version.version == '1.2.3'
 
         capture = capfd.readouterr()

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -700,7 +700,6 @@ class TestMetrics(IntegrationTest):
             assert os.request_id == request.id
             assert os.user_id == user_id
             assert os.occured_at == now - timedelta(seconds=2) + timedelta(seconds=16)
-            assert os.name == 'Endless'
             assert os.version == '3.5.3'
 
             crash = dbsession.query(ProgramDumpedCore).one()

--- a/azafea/event_processors/endless/metrics/tests/test_events.py
+++ b/azafea/event_processors/endless/metrics/tests/test_events.py
@@ -338,12 +338,12 @@ def test_new_unknown_event():
     (
         'OSVersion',
         GLib.Variant('(sss)', ('Endless', '3.5.3', 'obsolete and ignored')),
-        {'name': 'Endless', 'version': '3.5.3'}
+        {'version': '3.5.3'}
     ),
     (
         'OSVersion',
         GLib.Variant('(sss)', ('"Endless"', '"3.5.3"', 'obsolete and ignored')),
-        {'name': 'Endless', 'version': '3.5.3'}
+        {'version': '3.5.3'}
     ),
     (
         'ParentalControlsBlockedFlatpakInstall',

--- a/azafea/event_processors/endless/metrics/v2/cli.py
+++ b/azafea/event_processors/endless/metrics/v2/cli.py
@@ -514,12 +514,11 @@ def do_set_open_durations(config: Config, args: argparse.Namespace) -> None:
 
 def do_remove_os_info_quotes(config: Config, args: argparse.Namespace) -> None:
     db = Db(config.postgresql)
-    log.info('Remove leading and trailing quotes from OS version and name fields')
+    log.info('Remove leading and trailing quotes from OS version fields')
 
     with db as dbsession:
         query = dbsession.query(OSVersion).filter(or_(
             OSVersion.version.startswith('"'), OSVersion.version.endswith('"'),
-            OSVersion.name.startswith('"'), OSVersion.name.endswith('"'),
         ))
         num_records = query.count()
 
@@ -528,7 +527,6 @@ def do_remove_os_info_quotes(config: Config, args: argparse.Namespace) -> None:
             return None
 
         query.update({
-            OSVersion.name: func.btrim(OSVersion.name, '"'),
             OSVersion.version: func.btrim(OSVersion.version, '"'),
         }, synchronize_session=False)
         dbsession.commit()

--- a/azafea/event_processors/endless/metrics/v2/migrations/9184d25ca795_drop_os_name_column.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/9184d25ca795_drop_os_name_column.py
@@ -1,0 +1,27 @@
+# type: ignore
+
+"""Drop OS name column
+
+Revision ID: 9184d25ca795
+Revises: d4809698244a
+Create Date: 2020-05-11 16:53:31.556805
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9184d25ca795'
+down_revision = 'd4809698244a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('os_version', 'name')
+
+
+def downgrade():
+    op.add_column('os_version', sa.Column(
+        'name', sa.VARCHAR(), autoincrement=False, nullable=False, default='Endless'))


### PR DESCRIPTION
This PR removes the `name` column from the `os_version` table. This value is ulesess as it always is "Endless".

This is a draft because:
- ~it includes (and should be merged after) #111~ (merged),
- ~it includes an Alembic migration and thus has to be adjusted when #109 is merged~ (changed).

https://phabricator.endlessm.com/T29322