### PR TITLE
Store 2-letter country codes in database

### DIFF
--- a/azafea/event_processors/endless/activation/tests/integration/test_activation_cli.py
+++ b/azafea/event_processors/endless/activation/tests/integration/test_activation_cli.py
@@ -216,3 +216,61 @@ class TestActivation(IntegrationTest):
 
         capture = capfd.readouterr()
         assert 'No activation record with unparsed image ids' in capture.out
+
+    def test_transform_countries_alpha_3_to_2(self, capfd):
+        from azafea.event_processors.endless.activation.v1.handler import Activation
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Activation)
+
+        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        with self.db as dbsession:
+            activation = Activation(
+                image='unknown', product='product', release='release', country='FR',
+                created_at=created_at, vendor='vendor')
+            dbsession.add(activation)
+
+        with self.db as dbsession:
+            # Bypass ORM country validation
+            dbsession.execute("UPDATE activation_v1 SET country='FRA'")
+
+        with self.db as dbsession:
+            activation = dbsession.query(Activation).one()
+            assert activation.country == 'FRA'
+
+        # Parse the image for old activation records
+        self.run_subcommand(
+            'test_transform_countries_alpha_3_to_2',
+            'transform-countries-alpha-3-to-2')
+
+        with self.db as dbsession:
+            activation = dbsession.query(Activation).one()
+            assert activation.country == 'FR'
+
+    def test_transform_countries_alpha_3_to_2_only_2(self, capfd):
+        from azafea.event_processors.endless.activation.v1.handler import Activation
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Activation)
+
+        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        with self.db as dbsession:
+            activation = Activation(
+                image='unknown', product='product', release='release', country='FR',
+                created_at=created_at, vendor='vendor')
+            dbsession.add(activation)
+
+        self.run_subcommand(
+            'test_transform_countries_alpha_3_to_2_only_2',
+            'transform-countries-alpha-3-to-2')
+
+        with self.db as dbsession:
+            activation = dbsession.query(Activation).one()
+            assert activation.country == 'FR'
+
+        capture = capfd.readouterr()
+        assert 'No activation with alpha-3 country code found' in capture.out

--- a/azafea/event_processors/endless/activation/tests/integration/test_activation_cli.py
+++ b/azafea/event_processors/endless/activation/tests/integration/test_activation_cli.py
@@ -47,7 +47,7 @@ class TestActivation(IntegrationTest):
 
         with self.db as dbsession:
             dbsession.add(Activation(image='eos-eos3.7-amd64-amd64.190419-225606.base',
-                                     product='product', release='release', country='HKG',
+                                     product='product', release='release', country='HK',
                                      created_at=created_at, vendor=bad_vendor))
 
         with self.db as dbsession:
@@ -76,7 +76,7 @@ class TestActivation(IntegrationTest):
 
         with self.db as dbsession:
             dbsession.add(Activation(image='eos-eos3.7-amd64-amd64.190419-225606.base',
-                                     product='product', release='release', country='HKG',
+                                     product='product', release='release', country='HK',
                                      created_at=created_at, vendor=vendor))
 
         with self.db as dbsession:
@@ -103,7 +103,7 @@ class TestActivation(IntegrationTest):
 
         with self.db as dbsession:
             dbsession.add(Activation(image=image_id, product='product', release='release',
-                                     country='HKG', created_at=created_at, vendor='vendor'))
+                                     country='HK', created_at=created_at, vendor='vendor'))
 
         with self.db as dbsession:
             activation = dbsession.query(Activation).one()
@@ -146,7 +146,7 @@ class TestActivation(IntegrationTest):
                                      image_timestamp=datetime(2019, 4, 19, 22, 56, 6,
                                                               tzinfo=timezone.utc),
                                      image_personality='base', product='product', release='release',
-                                     country='HKG', created_at=created_at, vendor='vendor'))
+                                     country='HK', created_at=created_at, vendor='vendor'))
 
         with self.db as dbsession:
             activation = dbsession.query(Activation).one()
@@ -189,7 +189,7 @@ class TestActivation(IntegrationTest):
 
         with self.db as dbsession:
             dbsession.add(Activation(image=image_id, product='product', release='release',
-                                     country='HKG', created_at=created_at, vendor='vendor'))
+                                     country='HK', created_at=created_at, vendor='vendor'))
 
         with self.db as dbsession:
             activation = dbsession.query(Activation).one()

--- a/azafea/event_processors/endless/activation/tests/integration/test_activation_v1.py
+++ b/azafea/event_processors/endless/activation/tests/integration/test_activation_v1.py
@@ -30,7 +30,7 @@ class TestActivation(IntegrationTest):
             'vendor': 'the vendor',
             'product': 'product',
             'release': 'release',
-            'country': 'FRA',
+            'country': 'FR',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         }))
 
@@ -44,7 +44,7 @@ class TestActivation(IntegrationTest):
             assert activation.vendor == 'the vendor'
             assert activation.product == 'product'
             assert activation.release == 'release'
-            assert activation.country == 'FRA'
+            assert activation.country == 'FR'
             assert activation.created_at == created_at
             assert activation.image_product == 'eos'
             assert activation.image_branch == 'eos3.7'
@@ -68,7 +68,7 @@ class TestActivation(IntegrationTest):
             'vendor': 'the vendor',
             'product': 'product',
             'release': 'release',
-            'country': 'FRA',
+            'country': 'FR',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         }))
 
@@ -82,7 +82,7 @@ class TestActivation(IntegrationTest):
             assert activation.vendor == 'the vendor'
             assert activation.product == 'product'
             assert activation.release == 'release'
-            assert activation.country == 'FRA'
+            assert activation.country == 'FR'
             assert activation.created_at == created_at
             assert activation.image_product is None
             assert activation.image_branch is None
@@ -105,7 +105,7 @@ class TestActivation(IntegrationTest):
             'vendor': 'the vendor',
             'product': 'product',
             'release': 'release',
-            'country': 'FRA',
+            'country': 'FR',
             'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),
         }))
 

--- a/azafea/event_processors/endless/activation/tests/test_activation_validation.py
+++ b/azafea/event_processors/endless/activation/tests/test_activation_validation.py
@@ -25,7 +25,7 @@ def test_empty_country(country):
     assert activation.country is None
 
 
-@pytest.mark.parametrize('country', ['HK', 'Hong Kong'])
+@pytest.mark.parametrize('country', ['HOKG', 'Hong Kong'])
 def test_invalid_country(country):
     from azafea.event_processors.endless.activation.v1.handler import Activation
 

--- a/azafea/event_processors/endless/activation/tests/test_activation_validation.py
+++ b/azafea/event_processors/endless/activation/tests/test_activation_validation.py
@@ -13,8 +13,8 @@ import pytest
 def test_valid_country():
     from azafea.event_processors.endless.activation.v1.handler import Activation
 
-    activation = Activation(country='HKG')
-    assert activation.country == 'HKG'
+    activation = Activation(country='HK')
+    assert activation.country == 'HK'
 
 
 @pytest.mark.parametrize('country', ['', None])

--- a/azafea/event_processors/endless/activation/v1/cli.py
+++ b/azafea/event_processors/endless/activation/v1/cli.py
@@ -10,12 +10,14 @@ import argparse
 import logging
 
 from sqlalchemy.orm.query import Query
+from sqlalchemy.sql.expression import func
 
 from azafea.config import Config
 from azafea.model import Db
 from azafea.utils import progress
 from azafea.vendors import normalize_vendor
 
+from ...country import transform_alpha_3_into_2
 from ...image import parse_endless_os_image
 from .handler import Activation
 
@@ -37,6 +39,14 @@ def register_commands(subs: argparse._SubParsersAction) -> None:
     parse_images.add_argument('--chunk-size', type=int, default=5000,
                               help='The size of the chunks to operate on')
     parse_images.set_defaults(subcommand=do_parse_images)
+
+    transform_countries_alpha_3_to_2 = subs.add_parser(
+        'transform-countries-alpha-3-to-2',
+        help='Transform 3-letter country codes to 2-letter country codes',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    transform_countries_alpha_3_to_2.add_argument('--chunk-size', type=int, default=5000,
+                                                  help='The size of the chunks to operate on')
+    transform_countries_alpha_3_to_2.set_defaults(subcommand=do_transform_countries_alpha_3_to_2)
 
 
 def _normalize_chunk(chunk: Query) -> None:
@@ -98,5 +108,28 @@ def do_parse_images(config: Config, args: argparse.Namespace) -> None:
             progress(chunk_number * args.chunk_size, num_records)
 
     progress(num_records, num_records, end='\n')
+
+    log.info('All done!')
+
+
+def do_transform_countries_alpha_3_to_2(config: Config, args: argparse.Namespace) -> None:
+    db = Db(config.postgresql)
+    log.info('Transform alpha-3 country codes into alpha-2 for activations')
+
+    with db as dbsession:
+        query = dbsession.query(Activation).filter(func.length(Activation.country) == 3)
+        num_records = query.count()
+
+        if num_records == 0:
+            log.info('-> No activation with alpha-3 country code found')
+            return None
+
+        requests = transform_alpha_3_into_2(Activation.__tablename__)
+        for i, request in enumerate(requests, start=1):
+            dbsession.execute(request)
+            dbsession.commit()
+            progress(i, len(requests))
+
+    progress(len(requests), len(requests), end='\n')
 
     log.info('All done!')

--- a/azafea/event_processors/endless/activation/v1/handler.py
+++ b/azafea/event_processors/endless/activation/v1/handler.py
@@ -55,7 +55,7 @@ class Activation(Base):
     image_personality = Column(Unicode, index=True)
 
     __table_args__ = (
-        CheckConstraint('char_length(country) = 3', name='country_code_3_chars'),
+        CheckConstraint('char_length(country) in (2, 3)', name='country_code_2_3_chars'),
     )
 
     @validates('country')

--- a/azafea/event_processors/endless/activation/v1/handler.py
+++ b/azafea/event_processors/endless/activation/v1/handler.py
@@ -64,7 +64,7 @@ class Activation(Base):
         if not country:
             return None
 
-        if len(country) != 3:
+        if len(country) not in (2, 3):
             raise ValueError(f'country has wrong length: {country}')
 
         return country

--- a/azafea/event_processors/endless/activation/v1/migrations/a9e5d0f9b1cf_alpha_2_3_activation.py
+++ b/azafea/event_processors/endless/activation/v1/migrations/a9e5d0f9b1cf_alpha_2_3_activation.py
@@ -1,0 +1,30 @@
+# type: ignore
+
+"""Allow alpha2 and alpha3 country codes in activation_v1 table
+
+Revision ID: a9e5d0f9b1cf
+Revises: 3bf359e3c86c
+Create Date: 2020-05-14 15:14:02.100409
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a9e5d0f9b1cf'
+down_revision = '3bf359e3c86c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('ck_activation_v1_country_code_3_chars', 'activation_v1')
+    op.create_check_constraint(
+        'ck_activation_v1_country_code_2_3_chars', 'activation_v1',
+        'char_length(country) in (2, 3)')
+
+
+def downgrade():
+    op.drop_constraint('ck_activation_v1_country_code_2_3_chars', 'activation_v1')
+    op.create_check_constraint(
+        'ck_activation_v1_country_code_3_chars', 'activation_v1', 'char_length(country) = 3')

--- a/azafea/event_processors/endless/country.py
+++ b/azafea/event_processors/endless/country.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2020 - Endless OS LLC
+#
+# This file is part of Azafea
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from typing import List
+
+COUNTRIES = {
+    'AF': 'AFG', 'AL': 'ALB', 'DZ': 'DZA', 'AS': 'ASM', 'AD': 'AND', 'AO': 'AGO', 'AI': 'AIA',
+    'AQ': 'ATA', 'AG': 'ATG', 'AR': 'ARG', 'AM': 'ARM', 'AW': 'ABW', 'AU': 'AUS', 'AT': 'AUT',
+    'AZ': 'AZE', 'BS': 'BHS', 'BH': 'BHR', 'BD': 'BGD', 'BB': 'BRB', 'BY': 'BLR', 'BE': 'BEL',
+    'BZ': 'BLZ', 'BJ': 'BEN', 'BM': 'BMU', 'BT': 'BTN', 'BO': 'BOL', 'BQ': 'BES', 'BA': 'BIH',
+    'BW': 'BWA', 'BV': 'BVT', 'BR': 'BRA', 'IO': 'IOT', 'BN': 'BRN', 'BG': 'BGR', 'BF': 'BFA',
+    'BI': 'BDI', 'CV': 'CPV', 'KH': 'KHM', 'CM': 'CMR', 'CA': 'CAN', 'KY': 'CYM', 'CF': 'CAF',
+    'TD': 'TCD', 'CL': 'CHL', 'CN': 'CHN', 'CX': 'CXR', 'CC': 'CCK', 'CO': 'COL', 'KM': 'COM',
+    'CD': 'COD', 'CG': 'COG', 'CK': 'COK', 'CR': 'CRI', 'HR': 'HRV', 'CU': 'CUB', 'CW': 'CUW',
+    'CY': 'CYP', 'CZ': 'CZE', 'CI': 'CIV', 'DK': 'DNK', 'DJ': 'DJI', 'DM': 'DMA', 'DO': 'DOM',
+    'EC': 'ECU', 'EG': 'EGY', 'SV': 'SLV', 'GQ': 'GNQ', 'ER': 'ERI', 'EE': 'EST', 'SZ': 'SWZ',
+    'ET': 'ETH', 'FK': 'FLK', 'FO': 'FRO', 'FJ': 'FJI', 'FI': 'FIN', 'FR': 'FRA', 'GF': 'GUF',
+    'PF': 'PYF', 'TF': 'ATF', 'GA': 'GAB', 'GM': 'GMB', 'GE': 'GEO', 'DE': 'DEU', 'GH': 'GHA',
+    'GI': 'GIB', 'GR': 'GRC', 'GL': 'GRL', 'GD': 'GRD', 'GP': 'GLP', 'GU': 'GUM', 'GT': 'GTM',
+    'GG': 'GGY', 'GN': 'GIN', 'GW': 'GNB', 'GY': 'GUY', 'HT': 'HTI', 'HM': 'HMD', 'VA': 'VAT',
+    'HN': 'HND', 'HK': 'HKG', 'HU': 'HUN', 'IS': 'ISL', 'IN': 'IND', 'ID': 'IDN', 'IR': 'IRN',
+    'IQ': 'IRQ', 'IE': 'IRL', 'IM': 'IMN', 'IL': 'ISR', 'IT': 'ITA', 'JM': 'JAM', 'JP': 'JPN',
+    'JE': 'JEY', 'JO': 'JOR', 'KZ': 'KAZ', 'KE': 'KEN', 'KI': 'KIR', 'KP': 'PRK', 'KR': 'KOR',
+    'KW': 'KWT', 'KG': 'KGZ', 'LA': 'LAO', 'LV': 'LVA', 'LB': 'LBN', 'LS': 'LSO', 'LR': 'LBR',
+    'LY': 'LBY', 'LI': 'LIE', 'LT': 'LTU', 'LU': 'LUX', 'MO': 'MAC', 'MG': 'MDG', 'MW': 'MWI',
+    'MY': 'MYS', 'MV': 'MDV', 'ML': 'MLI', 'MT': 'MLT', 'MH': 'MHL', 'MQ': 'MTQ', 'MR': 'MRT',
+    'MU': 'MUS', 'YT': 'MYT', 'MX': 'MEX', 'FM': 'FSM', 'MD': 'MDA', 'MC': 'MCO', 'MN': 'MNG',
+    'ME': 'MNE', 'MS': 'MSR', 'MA': 'MAR', 'MZ': 'MOZ', 'MM': 'MMR', 'NA': 'NAM', 'NR': 'NRU',
+    'NP': 'NPL', 'NL': 'NLD', 'NC': 'NCL', 'NZ': 'NZL', 'NI': 'NIC', 'NE': 'NER', 'NG': 'NGA',
+    'NU': 'NIU', 'NF': 'NFK', 'MK': 'MKD', 'MP': 'MNP', 'NO': 'NOR', 'OM': 'OMN', 'PK': 'PAK',
+    'PW': 'PLW', 'PS': 'PSE', 'PA': 'PAN', 'PG': 'PNG', 'PY': 'PRY', 'PE': 'PER', 'PH': 'PHL',
+    'PN': 'PCN', 'PL': 'POL', 'PT': 'PRT', 'PR': 'PRI', 'QA': 'QAT', 'RO': 'ROU', 'RU': 'RUS',
+    'RW': 'RWA', 'RE': 'REU', 'BL': 'BLM', 'SH': 'SHN', 'KN': 'KNA', 'LC': 'LCA', 'MF': 'MAF',
+    'PM': 'SPM', 'VC': 'VCT', 'WS': 'WSM', 'SM': 'SMR', 'ST': 'STP', 'SA': 'SAU', 'SN': 'SEN',
+    'RS': 'SRB', 'SC': 'SYC', 'SL': 'SLE', 'SG': 'SGP', 'SX': 'SXM', 'SK': 'SVK', 'SI': 'SVN',
+    'SB': 'SLB', 'SO': 'SOM', 'ZA': 'ZAF', 'GS': 'SGS', 'SS': 'SSD', 'ES': 'ESP', 'LK': 'LKA',
+    'SD': 'SDN', 'SR': 'SUR', 'SJ': 'SJM', 'SE': 'SWE', 'CH': 'CHE', 'SY': 'SYR', 'TW': 'TWN',
+    'TJ': 'TJK', 'TZ': 'TZA', 'TH': 'THA', 'TL': 'TLS', 'TG': 'TGO', 'TK': 'TKL', 'TO': 'TON',
+    'TT': 'TTO', 'TN': 'TUN', 'TR': 'TUR', 'TM': 'TKM', 'TC': 'TCA', 'TV': 'TUV', 'UG': 'UGA',
+    'UA': 'UKR', 'AE': 'ARE', 'GB': 'GBR', 'UM': 'UMI', 'US': 'USA', 'UY': 'URY', 'UZ': 'UZB',
+    'VU': 'VUT', 'VE': 'VEN', 'VN': 'VNM', 'VG': 'VGB', 'VI': 'VIR', 'WF': 'WLF', 'EH': 'ESH',
+    'YE': 'YEM', 'ZM': 'ZMB', 'ZW': 'ZWE', 'AX': 'ALA', 'XK': 'XKX'}
+
+
+def transform_alpha_3_into_2(tablename: str) -> List[str]:
+    return [
+        f"UPDATE {tablename} SET country = '{alpha_2}' WHERE country = '{alpha_3}'"
+        for alpha_2, alpha_3 in COUNTRIES.items()]

--- a/azafea/event_processors/endless/ping/tests/integration/test_ping_cli.py
+++ b/azafea/event_processors/endless/ping/tests/integration/test_ping_cli.py
@@ -346,3 +346,64 @@ class TestPing(IntegrationTest):
 
         capture = capfd.readouterr()
         assert 'No ping record with unparsed image ids' in capture.out
+
+    def test_transform_countries_alpha_3_to_2(self, capfd):
+        from azafea.event_processors.endless.ping.v1.handler import Ping, PingConfiguration
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Ping)
+
+        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        with self.db as dbsession:
+            ping_config = PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                            product='product', dualboot=True, created_at=created_at,
+                                            vendor='EnDlEsS')
+            dbsession.add(ping_config)
+            dbsession.add(Ping(config=ping_config, release='release', count=0,
+                               created_at=created_at, country='FR'))
+
+        with self.db as dbsession:
+            # Bypass ORM country validation
+            dbsession.execute("UPDATE ping_v1 SET country='FRA'")
+
+        with self.db as dbsession:
+            ping = dbsession.query(Ping).one()
+            assert ping.country == 'FRA'
+
+        self.run_subcommand(
+            'test_transform_countries_alpha_3_to_2',
+            'transform-countries-alpha-3-to-2')
+
+        with self.db as dbsession:
+            ping = dbsession.query(Ping).one()
+            assert ping.country == 'FR'
+
+    def test_transform_countries_alpha_3_to_2_only_2(self, capfd):
+        from azafea.event_processors.endless.ping.v1.handler import Ping, PingConfiguration
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Ping)
+
+        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        with self.db as dbsession:
+            ping_config = PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
+                                            product='product', dualboot=True, created_at=created_at,
+                                            vendor='EnDlEsS')
+            dbsession.add(ping_config)
+            dbsession.add(Ping(config=ping_config, release='release', count=0,
+                               created_at=created_at, country='FR'))
+
+        self.run_subcommand(
+            'test_transform_countries_alpha_3_to_2_only_2',
+            'transform-countries-alpha-3-to-2')
+
+        with self.db as dbsession:
+            ping = dbsession.query(Ping).one()
+            assert ping.country == 'FR'
+
+        capture = capfd.readouterr()
+        assert 'No ping with alpha-3 country code found' in capture.out

--- a/azafea/event_processors/endless/ping/tests/test_ping_validation.py
+++ b/azafea/event_processors/endless/ping/tests/test_ping_validation.py
@@ -13,8 +13,8 @@ import pytest
 def test_valid_country():
     from azafea.event_processors.endless.ping.v1.handler import Ping
 
-    ping = Ping(country='HKG')
-    assert ping.country == 'HKG'
+    ping = Ping(country='HK')
+    assert ping.country == 'HK'
 
 
 @pytest.mark.parametrize('country', ['', None])

--- a/azafea/event_processors/endless/ping/tests/test_ping_validation.py
+++ b/azafea/event_processors/endless/ping/tests/test_ping_validation.py
@@ -25,7 +25,7 @@ def test_empty_country(country):
     assert ping.country is None
 
 
-@pytest.mark.parametrize('country', ['HK', 'Hong Kong'])
+@pytest.mark.parametrize('country', ['HOKG', 'Hong Kong'])
 def test_invalid_country(country):
     from azafea.event_processors.endless.ping.v1.handler import Ping
 

--- a/azafea/event_processors/endless/ping/v1/handler.py
+++ b/azafea/event_processors/endless/ping/v1/handler.py
@@ -92,7 +92,7 @@ class Ping(Base):
     created_at = Column(DateTime(timezone=True), nullable=False, index=True)
 
     __table_args__ = (
-        CheckConstraint('char_length(country) = 3', name='country_code_3_chars'),
+        CheckConstraint('char_length(country) in (2, 3)', name='country_code_2_3_chars'),
         CheckConstraint('count >= 0', name='count_positive'),
     )
 

--- a/azafea/event_processors/endless/ping/v1/handler.py
+++ b/azafea/event_processors/endless/ping/v1/handler.py
@@ -105,7 +105,7 @@ class Ping(Base):
         if not country:
             return None
 
-        if len(country) != 3:
+        if len(country) not in (2, 3):
             raise ValueError(f'country has wrong length: {country}')
 
         return country

--- a/azafea/event_processors/endless/ping/v1/migrations/f2d6141dbece_alpha_2_3_ping.py
+++ b/azafea/event_processors/endless/ping/v1/migrations/f2d6141dbece_alpha_2_3_ping.py
@@ -1,0 +1,29 @@
+# type: ignore
+
+"""Allow alpha2 and alpha3 country codes in ping_v1 table
+
+Revision ID: f2d6141dbece
+Revises: 439e90a6874a
+Create Date: 2020-05-14 15:13:41.564538
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'f2d6141dbece'
+down_revision = '439e90a6874a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('ck_ping_v1_country_code_3_chars', 'ping_v1')
+    op.create_check_constraint(
+        'ck_ping_v1_country_code_2_3_chars', 'ping_v1', 'char_length(country) in (2, 3)')
+
+
+def downgrade():
+    op.drop_constraint('ck_ping_v1_country_code_2_3_chars', 'ping_v1')
+    op.create_check_constraint(
+        'ck_ping_v1_country_code_3_chars', 'ping_v1', 'char_length(country) = 3')


### PR DESCRIPTION
This PR includes these changes:
- DB migration allowing both alpha2 and alpha3 codes in PostgreSQL,
- SQLAlchemy changes allowing ~~only alpha2~~ alpha2 and alpha3 codes when inserting new records,
- CLI commands added for country code migration in `ping_v1` and `activation_v1`.

https://phabricator.endlessm.com/T29210