### PR TITLE
Do not store empty values of location label information

### DIFF
--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -37,6 +37,7 @@ from ..machine import (
 )
 from ..utils import get_asv_dict, get_bytes, get_child_values, get_strings
 from ._base import (  # noqa: F401
+    EmptyPayloadError,
     SequenceEvent,
     SingularEvent,
     # Reexport some symbols
@@ -458,7 +459,12 @@ class LocationLabel(SingularEvent):
 
     @staticmethod
     def _get_fields_from_payload(payload: GLib.Variant) -> Dict[str, Any]:
-        return {'info': get_asv_dict(payload)}
+        # Empty values are removed as they are useless, even if they are sent
+        # by old versions of eos-metrics-instrumentation
+        info = {key: value for (key, value) in get_asv_dict(payload).items() if value}
+        if not info:
+            raise EmptyPayloadError('Location label event received with no data.')
+        return {'info': info}
 
 
 class MissingCodec(SingularEvent):

--- a/azafea/event_processors/endless/metrics/events/_base.py
+++ b/azafea/event_processors/endless/metrics/events/_base.py
@@ -64,6 +64,7 @@ IGNORED_EVENTS: Set[str] = {
 IGNORED_EMPTY_PAYLOAD_ERRORS: Set[str] = {
     '9af2cc74-d6dd-423f-ac44-600a6eee2d96',
     'add052be-7b2a-4959-81a5-a7f45062ee98',
+    'eb0302d8-62e7-274b-365f-cd4e59103983',
 }
 
 

--- a/azafea/event_processors/endless/metrics/tests/test_events.py
+++ b/azafea/event_processors/endless/metrics/tests/test_events.py
@@ -270,6 +270,11 @@ def test_new_unknown_event():
         {'info': {'city': 'City', 'state': 'State', 'facility': 'Facility'}}
     ),
     (
+        'LocationLabel',
+        GLib.Variant('a{ss}', {'city': '', 'state': '', 'facility': 'Facility'}),
+        {'info': {'facility': 'Facility'}}
+    ),
+    (
         'MissingCodec',
         GLib.Variant('(ssssa{sv})', (
             '1.16.0',
@@ -589,6 +594,19 @@ def test_invalid_parental_controls_changed_oars_event():
                                   "{'AppFilter': <(true, @as [])>, 'OarsFilter': <('not right', "
                                   "@a{ss} {})>, 'AllowUserInstallation': <false>, "
                                   "'AllowSystemInstallation': <false>}")
+
+
+def test_empty_location_label():
+    from azafea.event_processors.endless.metrics.events import LocationLabel
+    from azafea.event_processors.endless.metrics.events._base import EmptyPayloadError
+
+    # Make an invalid payload with missing keys
+    payload = GLib.Variant('mv', GLib.Variant('a{ss}', {'empty': ''}))
+
+    with pytest.raises(EmptyPayloadError) as excinfo:
+        LocationLabel(payload)
+
+    assert str(excinfo.value) == 'Location label event received with no data.'
 
 
 @pytest.mark.parametrize('event_model_name, payload, expected_attrs', [


### PR DESCRIPTION
Empty values are sent by old versions of eos-metrics-instrumentation because gnome-initial-setup stores them in the configuration file by mistake. These empty strings are useless, we do not want to keep them in the database.

https://phabricator.endlessm.com/T29561