### PR TITLE
Add index on the activation image column

### DIFF
--- a/azafea/event_processors/endless/activation/v1/handler.py
+++ b/azafea/event_processors/endless/activation/v1/handler.py
@@ -28,7 +28,7 @@ class Activation(Base):
     __tablename__ = 'activation_v1'
 
     id = Column(Integer, primary_key=True)
-    image = Column(Unicode, nullable=False)
+    image = Column(Unicode, nullable=False, index=True)
     vendor = Column(Unicode, nullable=False)
     product = Column(Unicode, nullable=False)
     release = Column(Unicode, nullable=False)

--- a/azafea/event_processors/endless/activation/v1/migrations/39a1079daf52_activation_image_index.py
+++ b/azafea/event_processors/endless/activation/v1/migrations/39a1079daf52_activation_image_index.py
@@ -1,0 +1,25 @@
+# type: ignore
+
+"""Activation image index.
+
+Revision ID: 39a1079daf52
+Revises: 3bf359e3c86c
+Create Date: 2020-07-08 13:39:34.620812
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '39a1079daf52'
+down_revision = '3bf359e3c86c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f('ix_activation_v1_image'), 'activation_v1', ['image'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_activation_v1_image'), table_name='activation_v1')


### PR DESCRIPTION
This index improves speed of requests filtering on the activation image name.

Fix #21.