### PR TITLE
metrics: Process "underscan enabled" events

### DIFF
--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -728,6 +728,12 @@ class ShellAppRemovedFromDesktop(SingularEvent):
         return {'app_id': payload.get_string()}
 
 
+class UnderscanEnabled(SingularEvent):
+    __tablename__ = 'underscan_enabled'
+    __event_uuid__ = '304662c0-fdce-46b8-aa39-d1beb097efcd'
+    __payload_type__ = None
+
+
 class UpdaterBranchSelected(SingularEvent):
     __tablename__ = 'updater_branch_selected'
     __event_uuid__ = '99f48aac-b5a0-426d-95f4-18af7d081c4e'

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -168,8 +168,8 @@ class TestMetrics(IntegrationTest):
             LaunchedExistingFlatpak, LaunchedInstallerForFlatpak, LinuxPackageOpened, LiveUsbBooted,
             Location, LocationLabel, MissingCodec, MonitorConnected, MonitorDisconnected, NetworkId,
             OSVersion, ProgramDumpedCore, RAMSize, ShellAppAddedToDesktop,
-            ShellAppRemovedFromDesktop, UpdaterBranchSelected, Uptime, WindowsAppOpened,
-            WindowsLicenseTables,
+            ShellAppRemovedFromDesktop, UnderscanEnabled, UpdaterBranchSelected, Uptime,
+            WindowsAppOpened, WindowsLicenseTables,
         )
         from azafea.event_processors.endless.metrics.events._base import (
             InvalidSingularEvent, UnknownSingularEvent,
@@ -188,8 +188,8 @@ class TestMetrics(IntegrationTest):
             LaunchedExistingFlatpak, LaunchedInstallerForFlatpak, LinuxPackageOpened, LiveUsbBooted,
             Location, LocationLabel, MissingCodec, MonitorConnected, MonitorDisconnected, NetworkId,
             OSVersion, ProgramDumpedCore, RAMSize, ShellAppAddedToDesktop,
-            ShellAppRemovedFromDesktop, UpdaterBranchSelected, Uptime, WindowsAppOpened,
-            WindowsLicenseTables,
+            ShellAppRemovedFromDesktop, UnderscanEnabled, UpdaterBranchSelected, Uptime,
+            WindowsAppOpened, WindowsLicenseTables,
         )
 
         # Build a request as it would have been sent to us
@@ -431,6 +431,12 @@ class TestMetrics(IntegrationTest):
                         UUID('683b40a7-cac0-4f9a-994c-4b274693a0a0').bytes,
                         24000000000,                   # event relative timestamp (24 secs)
                         GLib.Variant('s', 'org.gnome.Evolution')
+                    ),
+                    (
+                        user_id,
+                        UUID('304662c0-fdce-46b8-aa39-d1beb097efcd').bytes,
+                        36000000000,                   # event relative timestamp (36 secs)
+                        None
                     ),
                     (
                         user_id,
@@ -725,6 +731,11 @@ class TestMetrics(IntegrationTest):
             assert app_removed.user_id == user_id
             assert app_removed.occured_at == now - timedelta(seconds=2) + timedelta(seconds=24)
             assert app_removed.app_id == 'org.gnome.Evolution'
+
+            underscan = dbsession.query(UnderscanEnabled).one()
+            assert underscan.request_id == request.id
+            assert underscan.user_id == user_id
+            assert underscan.occured_at == now - timedelta(seconds=2) + timedelta(seconds=36)
 
             branch = dbsession.query(UpdaterBranchSelected).one()
             assert branch.request_id == request.id

--- a/azafea/event_processors/endless/metrics/tests/test_events.py
+++ b/azafea/event_processors/endless/metrics/tests/test_events.py
@@ -483,6 +483,7 @@ def test_new_unknown_event():
         GLib.Variant('s', 'org.gnome.Evolution'),
         {'app_id': 'org.gnome.Evolution'}
     ),
+    ('UnderscanEnabled', None, {}),
     (
         'UpdaterBranchSelected',
         GLib.Variant('(sssb)', (

--- a/azafea/event_processors/endless/metrics/v2/migrations/961fbbaf2cf7_add_the_underscan_enabled_event.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/961fbbaf2cf7_add_the_underscan_enabled_event.py
@@ -1,0 +1,38 @@
+# type: ignore
+
+"""Add the underscan enabled event
+
+Revision ID: 961fbbaf2cf7
+Revises: 5393df905032
+Create Date: 2020-09-16 16:15:11.496377
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '961fbbaf2cf7'
+down_revision = '5393df905032'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('underscan_enabled',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('user_id', sa.BigInteger(), nullable=False),
+                    sa.Column('occured_at', sa.DateTime(timezone=True), nullable=False),
+                    sa.Column('request_id', sa.Integer(), nullable=True),
+                    sa.ForeignKeyConstraint(
+                        ['request_id'], ['metrics_request_v2.id'],
+                        name=op.f('fk_underscan_enabled_request_id_metrics_request_v2')),
+                    sa.PrimaryKeyConstraint('id', name=op.f('pk_underscan_enabled'))
+                    )
+    op.create_index(op.f('ix_underscan_enabled_request_id'), 'underscan_enabled', ['request_id'],
+                    unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_underscan_enabled_request_id'), table_name='underscan_enabled')
+    op.drop_table('underscan_enabled')


### PR DESCRIPTION
This commit is "inspired" by the following one:
metrics: Process the "demo mode entered" events

https://phabricator.endlessm.com/T30766