### PR TITLE
Store machine location into metrics_machine table

### DIFF
--- a/azafea/event_processors/endless/metrics/events/__init__.py
+++ b/azafea/event_processors/endless/metrics/events/__init__.py
@@ -34,6 +34,7 @@ from ..machine import (
     upsert_machine_dualboot,
     upsert_machine_image,
     upsert_machine_live,
+    upsert_machine_location,
 )
 from ..utils import clamp_to_int64, get_bytes, get_child_values
 from ._base import (  # noqa: F401
@@ -1728,3 +1729,7 @@ def receive_before_commit(dbsession: DbSession) -> None:
         elif isinstance(instance, LiveUsbBooted):
             dbsession.enable_relationship_loading(instance)
             upsert_machine_live(dbsession, instance.request.machine_id)
+
+        elif isinstance(instance, LocationLabel):
+            dbsession.enable_relationship_loading(instance)
+            upsert_machine_location(dbsession, instance.request.machine_id, info=instance.info)

--- a/azafea/event_processors/endless/metrics/machine.py
+++ b/azafea/event_processors/endless/metrics/machine.py
@@ -7,16 +7,20 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
+import logging
 
-from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.schema import Column
+from sqlalchemy.dialects.postgresql import JSONB, insert
+from sqlalchemy.schema import Column, Index
 from sqlalchemy.sql import expression
 from sqlalchemy.types import Boolean, DateTime, Integer, Unicode
 
 from azafea.model import Base, DbSession
 
 from ..image import parse_endless_os_image
+
+
+log = logging.getLogger(__name__)
 
 
 class Machine(Base):
@@ -34,6 +38,28 @@ class Machine(Base):
     demo = Column(Boolean, server_default=expression.false())
     dualboot = Column(Boolean, server_default=expression.false())
     live = Column(Boolean, server_default=expression.false())
+    location = Column(JSONB)
+    location_id = Column(Unicode)
+    location_city = Column(Unicode)
+    location_state = Column(Unicode)
+    location_street = Column(Unicode)
+    location_country = Column(Unicode)
+    location_facility = Column(Unicode)
+
+    __table_args__ = (
+        Index('ix_metrics_machine_location_id', location_id,
+              postgresql_where=(location_id.isnot(None))),
+        Index('ix_metrics_machine_location_city', location_city,
+              postgresql_where=(location_city.isnot(None))),
+        Index('ix_metrics_machine_location_state', location_state,
+              postgresql_where=(location_state.isnot(None))),
+        Index('ix_metrics_machine_location_street', location_street,
+              postgresql_where=(location_street.isnot(None))),
+        Index('ix_metrics_machine_location_country', location_country,
+              postgresql_where=(location_country.isnot(None))),
+        Index('ix_metrics_machine_location_facility', location_facility,
+              postgresql_where=(location_facility.isnot(None))),
+    )
 
 
 def upsert_machine_demo(dbsession: DbSession, machine_id: str) -> None:
@@ -67,3 +93,27 @@ def upsert_machine_live(dbsession: DbSession, machine_id: str) -> None:
                                       set_={'live': True})
 
     dbsession.connection().execute(stmt)
+
+
+def upsert_machine_location(dbsession: DbSession, machine_id: str,
+                            info: Union[Dict[str, Any], List[Any]]) -> None:
+    """Update the relevant Machine record with information from a LocationLabel event.
+
+    Although the info is guaranteed to be a `Dict[str, str]` when received from
+    the client, the database column is of type JSONB, so the
+    `LocationLabel.info` field has a more general type. As a result, the
+    function parameter also has a more general type, and this runtime type
+    check is needed to satisfy mypy.
+
+    """
+    if isinstance(info, dict):
+        location_columns = [column.name for column in Machine.__table__.columns]
+        values = {
+            f'location_{key}': value for key, value in info.items()
+            if f'location_{key}' in location_columns}
+        stmt = insert(Machine.__table__).values(machine_id=machine_id, location=info, **values)
+        stmt = stmt.on_conflict_do_update(constraint='uq_metrics_machine_machine_id', set_=values)
+
+        dbsession.connection().execute(stmt)
+    else:  # pragma: no cover
+        log.warning('Data received for machine location is not a dict: %r', info)

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_cli.py
@@ -1077,7 +1077,7 @@ class TestMetrics(IntegrationTest):
                               send_number=0)
             dbsession.add(request)
             dbsession.add(LocationLabel(
-                user_id=1, occured_at=occured_at, request_id=request.id, payload=payload))
+                user_id=1, occured_at=occured_at, request=request, payload=payload))
 
         self.run_subcommand('test_remove_empty_location_info_none', 'remove-empty-location-info')
 
@@ -1115,9 +1115,9 @@ class TestMetrics(IntegrationTest):
                               send_number=0)
             dbsession.add(request)
             dbsession.add(LocationLabel(
-                user_id=1, occured_at=occured_at, request_id=request.id, payload=payload))
+                user_id=1, occured_at=occured_at, request=request, payload=payload))
             empty_location = LocationLabel(
-                user_id=1, occured_at=occured_at, request_id=request.id, payload=payload)
+                user_id=1, occured_at=occured_at, request=request, payload=payload)
             empty_location.info = empty_info
             dbsession.add(empty_location)
 

--- a/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests/integration/test_metrics_v2.py
@@ -1353,6 +1353,184 @@ class TestMetrics(IntegrationTest):
             assert machine.dualboot is False
             assert machine.live is True
 
+    def test_upsert_machine_location_then_image_id(self):
+        from azafea.event_processors.endless.metrics.events import ImageVersion, LocationLabel
+        from azafea.event_processors.endless.metrics.machine import Machine
+        from azafea.event_processors.endless.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request, Machine, ImageVersion, LocationLabel)
+
+        # Build a request as it would have been sent to us
+        now = datetime.now(tz=timezone.utc)
+        machine_id = 'ffffffffffffffffffffffffffffffff'
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id),
+                [                                      # singular events
+                    (
+                        1001,
+                        UUID('eb0302d8-62e7-274b-365f-cd4e59103983').bytes,
+                        2000000000,                    # event relative timestamp (2 secs)
+                        GLib.Variant('a{ss}', {
+                            'city': 'City', 'state': 'State', 'facility': 'Facility'})
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_upsert_machine_location_then_image_id', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).one()
+
+            location = dbsession.query(LocationLabel).one()
+            assert location.request_id == request.id
+
+            machine = dbsession.query(Machine).one()
+            assert machine.machine_id == request.machine_id
+            assert machine.image_id is None
+            assert machine.location == {'city': 'City', 'state': 'State', 'facility': 'Facility'}
+            assert machine.location_city == 'City'
+            assert machine.location_state == 'State'
+            assert machine.location_facility == 'Facility'
+
+        # Build a request as it would have been sent to us
+        now = datetime.now(tz=timezone.utc)
+        machine_id = 'ffffffffffffffffffffffffffffffff'
+        image_id = 'eosoem-eos3.7-amd64-amd64.190419-225606.base'
+        user_id = 2000
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id),
+                [                                      # singular events
+                    (
+                        user_id,
+                        UUID('6b1c1cfc-bc36-438c-0647-dacd5878f2b3').bytes,
+                        1000000000,                    # event relative timestamp (1 secs)
+                        GLib.Variant('s', image_id)
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_upsert_machine_location_then_image_id', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).order_by(Request.received_at.desc()).first()
+
+            image = dbsession.query(ImageVersion).one()
+            assert image.request_id == request.id
+            assert image.image_id == image_id
+
+            machine = dbsession.query(Machine).one()
+            assert machine.machine_id == request.machine_id
+            assert machine.image_id == image_id
+            assert machine.location == {'city': 'City', 'state': 'State', 'facility': 'Facility'}
+            assert machine.location_city == 'City'
+            assert machine.location_state == 'State'
+            assert machine.location_facility == 'Facility'
+
+    def test_upsert_machine_location_unknown_keys(self):
+        from azafea.event_processors.endless.metrics.events import ImageVersion, LocationLabel
+        from azafea.event_processors.endless.metrics.machine import Machine
+        from azafea.event_processors.endless.metrics.request import Request
+
+        # Create the table
+        self.run_subcommand('initdb')
+        self.ensure_tables(Request, Machine, ImageVersion, LocationLabel)
+
+        # Build a request as it would have been sent to us
+        now = datetime.now(tz=timezone.utc)
+        machine_id = 'ffffffffffffffffffffffffffffffff'
+        request = GLib.Variant(
+            '(ixxaya(uayxmv)a(uayxxmv)a(uaya(xmv)))',
+            (
+                0,                                     # network send number
+                2000000000,                            # request relative timestamp (2 secs)
+                int(now.timestamp() * 1000000000),     # request absolute timestamp
+                bytes.fromhex(machine_id),
+                [                                      # singular events
+                    (
+                        1001,
+                        UUID('eb0302d8-62e7-274b-365f-cd4e59103983').bytes,
+                        2000000000,                    # event relative timestamp (2 secs)
+                        GLib.Variant('a{ss}', {
+                            'city': 'City', 'state': 'State', 'unknown': 'Unknown'})
+                    ),
+                ],
+                [],                                    # aggregate events
+                []                                     # sequence events
+            )
+        )
+        assert request.is_normal_form()
+        request_body = request.get_data_as_bytes().get_data()
+
+        received_at = now + timedelta(minutes=2)
+        received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+        received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+        record = received_at_timestamp_bytes + request_body
+
+        # Send the event request to the Redis queue
+        self.redis.lpush('test_upsert_machine_location_unknown_keys', record)
+
+        # Run Azafea so it processes the event
+        self.run_azafea()
+
+        # Ensure the record was inserted into the DB
+        with self.db as dbsession:
+            request = dbsession.query(Request).one()
+
+            location = dbsession.query(LocationLabel).one()
+            assert location.request_id == request.id
+
+            machine = dbsession.query(Machine).one()
+            assert machine.machine_id == request.machine_id
+            assert machine.image_id is None
+            assert machine.location == {'city': 'City', 'state': 'State', 'unknown': 'Unknown'}
+            assert machine.location_city == 'City'
+            assert machine.location_state == 'State'
+
     def test_upsert_machine_all_at_once(self):
         from azafea.event_processors.endless.metrics.events import (
             DualBootBooted, EnteredDemoMode, ImageVersion, LiveUsbBooted)

--- a/azafea/event_processors/endless/metrics/v2/migrations/991574509c57_add_machine_location_columns.py
+++ b/azafea/event_processors/endless/metrics/v2/migrations/991574509c57_add_machine_location_columns.py
@@ -1,0 +1,120 @@
+# type: ignore
+
+"""Add machine location columns
+
+Revision ID: 991574509c57
+Revises: 98078d059259
+Create Date: 2020-12-03 12:33:17.219965
+
+"""
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql.expression import text
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '991574509c57'
+down_revision = '98078d059259'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('metrics_machine', sa.Column('location', JSONB(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('location_city', sa.Unicode(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('location_country', sa.Unicode(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('location_facility', sa.Unicode(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('location_id', sa.Unicode(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('location_state', sa.Unicode(), nullable=True))
+    op.add_column('metrics_machine', sa.Column('location_street', sa.Unicode(), nullable=True))
+    op.create_index(
+        op.f('ix_metrics_machine_location_city'), 'metrics_machine', ['location_city'],
+        postgresql_where=text("location_city is not null"))
+    op.create_index(
+        op.f('ix_metrics_machine_location_country'), 'metrics_machine', ['location_country'],
+        postgresql_where=text("location_country is not null"))
+    op.create_index(
+        op.f('ix_metrics_machine_location_facility'), 'metrics_machine', ['location_facility'],
+        postgresql_where=text("location_facility is not null"))
+    op.create_index(
+        op.f('ix_metrics_machine_location_id'), 'metrics_machine', ['location_id'],
+        postgresql_where=text("location_id is not null"))
+    op.create_index(
+        op.f('ix_metrics_machine_location_state'), 'metrics_machine', ['location_state'],
+        postgresql_where=text("location_state is not null"))
+    op.create_index(
+        op.f('ix_metrics_machine_location_street'), 'metrics_machine', ['location_street'],
+        postgresql_where=text("location_street is not null"))
+    op.execute('''
+      INSERT INTO
+        metrics_machine
+        (
+          location,
+          location_street,
+          location_state,
+          location_id,
+          location_facility,
+          location_country,
+          location_city,
+          machine_id
+        )
+        (
+          SELECT
+            location,
+            location_street,
+            location_state,
+            location_id,
+            location_facility,
+            location_country,
+            location_city,
+            machine_id
+          FROM (
+            SELECT
+              info AS location,
+              info->'street' AS location_street,
+              info->'state' AS location_state,
+              info->'id' AS location_id,
+              info->'facility' AS location_facility,
+              info->'country' AS location_country,
+              info->'city' AS location_city,
+              machine_id,
+              rank() OVER (PARTITION BY machine_id ORDER BY occured_at DESC) AS rank
+            FROM
+              location_event
+            JOIN
+              metrics_request_v2
+            ON
+              request_id=metrics_request_v2.id
+            ORDER BY occured_at
+          ) AS ranked_location
+          WHERE
+            rank = 1
+        )
+        ON CONFLICT ON CONSTRAINT
+          uq_metrics_machine_machine_id
+        DO UPDATE SET
+          location=excluded.location,
+          location_street=excluded.location_street,
+          location_state=excluded.location_state,
+          location_id=excluded.location_id,
+          location_facility=excluded.location_facility,
+          location_country=excluded.location_country,
+          location_city=excluded.location_country;
+    ''')
+
+
+def downgrade():
+    op.drop_index(op.f('ix_metrics_machine_location_street'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_location_state'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_location_id'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_location_facility'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_location_country'), table_name='metrics_machine')
+    op.drop_index(op.f('ix_metrics_machine_location_city'), table_name='metrics_machine')
+    op.drop_column('metrics_machine', 'location_street')
+    op.drop_column('metrics_machine', 'location_state')
+    op.drop_column('metrics_machine', 'location_id')
+    op.drop_column('metrics_machine', 'location_facility')
+    op.drop_column('metrics_machine', 'location_country')
+    op.drop_column('metrics_machine', 'location_city')
+    op.drop_column('metrics_machine', 'location')


### PR DESCRIPTION
Instead of storing machine location in events, we can store it in the metrics_machine table and upsert when new events happen.

The deployment creates the new columns and sets the values according to the events already stored in the database.

The event table is not removed yet. This way, we can check that everything is OK for a while, and keep events if anything goes wrong.

This is the first step of https://phabricator.endlessm.com/T30471.