### PR TITLE
Publish the Docker image to Docker Hub.

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,35 @@
+---
+name: &name Upload the Docker image to Docker Hub
+on:
+  workflow_run:
+    workflows:
+      - Azafea Tests
+    branches:
+      - master
+    types:
+      - completed
+
+jobs:
+  push:
+    name: *name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: '${{ secrets.DOCKERHUB_USERNAME }}'
+          password: '${{ secrets.DOCKERHUB_TOKEN }}'
+
+      - name: Get Docker Image
+        uses: actions/download-artifact@v2
+        with:
+          name: image
+
+      - name: Load Docker Image
+        run: docker load < docker-image.tar
+
+      - name: Tag image
+        run: docker tag azafea-tests endlessm/azafea
+
+      - name: Upload the image
+        run: docker push endlessm/azafea


### PR DESCRIPTION
GitHub Actions workflow to publish the Docker image to Docker Hub. Use
the image built during the tests workflow. Only run on changes to the
master branch and only after the test workflow has finished
successfully.

https://phabricator.endlessm.com/T31467