### PR TITLE
Test documentation builds in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,3 @@
 /build
 /dist
 /Dockerfile
-/docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,21 @@ jobs:
       - name: Lint and Type Checking
         run: docker run --rm --network=host --entrypoint="" azafea-tests pipenv run lint
 
+  doc:
+    name: Documentation Building Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Docker Image
+        uses: actions/download-artifact@v2
+        with:
+          name: image
+      - name: Load Docker Image
+        run: docker load < docker-image.tar
+      - name: Documentation Building Test
+        run: docker run --rm --network=host --entrypoint="" azafea-tests pipenv run doc -nW --keep-going
+
   push:
     name: Upload the Docker image to Docker Hub
     runs-on: ubuntu-latest

--- a/docs/source/queue-plugins.rst
+++ b/docs/source/queue-plugins.rst
@@ -268,20 +268,18 @@ anything wrong to happen.
 When multiple branches are deployed, their commit numbers will all be included
 in the ``alembic_version`` table. It is then impossible to create a new
 deployment, as Alembic can't know which head should be the parent. The solution
-is then to merge the branches, using a merge deployment script:
+is then to merge the branches, using a merge deployment script::
 
-```
-revision = '<random_hash>'
-down_revision = ('<head_1_hash>', '<head_2_hash>', …)
-branch_labels = None
-depends_on = None
+    revision = '<random_hash>'
+    down_revision = ('<head_1_hash>', '<head_2_hash>', …)
+    branch_labels = None
+    depends_on = None
 
-def upgrade():
-    pass
+    def upgrade():
+        pass
 
-def downgrade():
-    pass
-```
+    def downgrade():
+        pass
 
 This deployment does not modify the database schema, but it replaces the old
 head hashes with the new one in the ``alembic_version`` table. Alembic is then


### PR DESCRIPTION
Sphinx is pretty tolerant while building the documentation, and we already missed silent errors and warnings for documentation on production.

The problem appeared again during the metrics v2/v3 reorganization, with no obvious warning sign being raised. Testing documentation builds in CI should avoid problems in the future.

Note that this commit includes docs in the Docker image.