### PR TITLE
Use the server’s clock when it’s obviously better than the client’s

### DIFF
--- a/azafea/event_processors/endless/metrics/tests_v3/test_request.py
+++ b/azafea/event_processors/endless/metrics/tests_v3/test_request.py
@@ -69,3 +69,40 @@ def test_request_builder_invalid():
 
     assert ('Metric request is not in the expected format: '
             '(xxsa{ss}ya(aysxmv)a(ayssumv))') in str(excinfo.value)
+
+
+def test_request_builder_wrong_client_clock():
+    from azafea.event_processors.endless.metrics.v3.model import parse_record
+
+    now = datetime.now(tz=timezone.utc)
+    request = GLib.Variant(
+        '(xxsa{ss}ya(aysxmv)a(ayssumv))',
+        (
+            2000000,   # request relative timestamp (2 secs)
+            int((now - timedelta(hours=1)).timestamp() * 1000000000),  # Abs. timestamp, 1 hour late
+            'image_id',
+            {},
+            2,
+            [],                                    # singular events
+            []                                     # sequence events
+        )
+    )
+    assert request.is_normal_form()
+    request_body = request.get_data_as_bytes().get_data()
+
+    received_at = now + timedelta(minutes=2)
+    received_at_timestamp = int(received_at.timestamp() * 1000000)  # timestamp as microseconds
+    received_at_timestamp_bytes = received_at_timestamp.to_bytes(8, 'little')
+
+    record = received_at_timestamp_bytes + request_body
+
+    request, channel = parse_record(record)
+    assert request.relative_timestamp == 2000000
+    # Server clock, rounded because it’s only sent in microseconds
+    assert round(request.absolute_timestamp / 1000) == int(received_at.timestamp() * 1000000)
+    assert list(request.singulars) == []
+    assert list(request.aggregates) == []
+
+    assert channel.live
+    assert not channel.dual_boot
+    assert channel.image_id == 'image_id'

--- a/azafea/event_processors/endless/metrics/v3/utils.py
+++ b/azafea/event_processors/endless/metrics/v3/utils.py
@@ -36,7 +36,7 @@ def get_variant(value: GLib.Variant) -> GLib.Variant:
     return value
 
 
-# See the timestamp-algorithm.rst file in this directory for details
+# See docs/source/timestamp-algorithm.rst in this repository for details
 def get_event_datetime(request_absolute_timestamp: int, request_relative_timestamp: int,
                        event_relative_timestamp: int) -> datetime:
     origin_boot_absolute_timestamp = request_absolute_timestamp - request_relative_timestamp


### PR DESCRIPTION
This is the last part of the timestamp algorithm:
https://azafea.readthedocs.io/en/latest/timestamp-algorithm.html#server-side

"When the server receives a network request, it will first examine the network request absolute time to see if it varies significantly from its own (trusted) clock. If it does, some special action will be taken with that request, such as putting it in its own special table or attempting to correct the timestamp in some fashion."

Our "attempt to correct the timestamp" happens when:
- the request is received before it has been sent (1 second tolerance),
- the request is received a long time after it has been sent (10 minutes tolerance).
In these two cases, we prefer to use the server’s clock, because the client’s clock is obviously wrong.

~https://phabricator.endlessm.com/T29275~ https://phabricator.endlessm.com/T32195