### PR TITLE
Read the Docs environment

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,6 +5,22 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-20.04
+
+  tools:
+    # Keep this in sync with the Dockerfile python image version.
+    python: "3.8"
+
+  # System packages needed for python requirements.
+  apt_packages:
+    # pycairo, dependency of pygobject
+    - libcairo2-dev
+    # pygobject
+    - libgirepository1.0-dev
+    # psycopg2
+    - libpq-dev
+
 python:
   install:
     - requirements: requirements.readthedocs.txt


### PR DESCRIPTION
Install system packages required for python packages and specify the python version to Read the Docs. This should hopefully get things moving again and make the environment more consistent.

https://phabricator.endlessm.com/T32700