### PR TITLE
metrics: Add SplitFlatpakRepoStats event

### DIFF
--- a/azafea/event_processors/endless/metrics/tests_v2/test_utils.py
+++ b/azafea/event_processors/endless/metrics/tests_v2/test_utils.py
@@ -9,6 +9,7 @@
 
 from datetime import datetime, timezone
 from gi.repository import GLib
+import logging
 
 import pytest
 
@@ -47,3 +48,30 @@ def test_get_event_datetime():
 
     assert get_event_datetime(1536122990000000000, 20000000000, 30000000000) \
         == datetime(2018, 9, 5, 4, 50, tzinfo=timezone.utc)
+
+
+def test_clamp_to_int64(caplog):
+    from azafea.event_processors.endless.metrics.v2.utils import clamp_to_int64, log as utils_log
+
+    val = clamp_to_int64(GLib.MAXUINT64)
+    assert val == GLib.MAXINT64
+    assert caplog.records != []
+
+    # Check that the message and exception come through.
+    record = caplog.records[0]
+    assert record.name == utils_log.name
+    assert record.levelno == logging.ERROR
+    assert record.msg == f'Clamped integer larger than MAXINT64: {GLib.MAXUINT64}'
+    assert record.exc_info is not None
+    assert record.exc_info[0] == ValueError
+    assert str(record.exc_info[1]) == f'{GLib.MAXUINT64} larger than {GLib.MAXINT64}'
+
+    caplog.clear()
+    val = clamp_to_int64(GLib.MAXINT64)
+    assert val == GLib.MAXINT64
+    assert caplog.records == []
+
+    caplog.clear()
+    val = clamp_to_int64(GLib.MAXINT64 + 1)
+    assert val == GLib.MAXINT64
+    assert caplog.records != []

--- a/azafea/event_processors/endless/metrics/tests_v3/integration/test_metrics_v3.py
+++ b/azafea/event_processors/endless/metrics/tests_v3/integration/test_metrics_v3.py
@@ -187,7 +187,8 @@ class TestMetrics(IntegrationTest):
             LaunchedExistingFlatpak, LaunchedInstallerForFlatpak, LinuxPackageOpened,
             ParentalControlsBlockedFlatpakInstall, ParentalControlsBlockedFlatpakRun,
             ProgramDumpedCore, UpdaterFailure, ParentalControlsEnabled,
-            ParentalControlsChanged, WindowsAppOpened, ComputerInformation
+            ParentalControlsChanged, WindowsAppOpened, ComputerInformation,
+            SplitFlatpakRepoStats,
         )
         from azafea.event_processors.endless.metrics.v3.model import _base
         _base.IGNORED_EMPTY_PAYLOAD_ERRORS = ['9d03daad-f1ed-41a8-bc5a-6b532c075832']
@@ -200,7 +201,8 @@ class TestMetrics(IntegrationTest):
             LaunchedExistingFlatpak, LaunchedInstallerForFlatpak, LinuxPackageOpened,
             ParentalControlsBlockedFlatpakInstall, ParentalControlsBlockedFlatpakRun,
             ProgramDumpedCore, UpdaterFailure, ParentalControlsEnabled,
-            ParentalControlsChanged, WindowsAppOpened, ComputerInformation
+            ParentalControlsChanged, WindowsAppOpened, ComputerInformation,
+            SplitFlatpakRepoStats,
         )
 
         # Build a request as it would have been sent to us
@@ -370,7 +372,27 @@ class TestMetrics(IntegrationTest):
                                 [('model_1', 8, 14.5), ('model_2', 8, 14.5)]
                             )
                         )
-                    )
+                    ),
+                    (
+                        UUID('880fd091-2e68-4bd2-baa1-f6810fabcc1c').bytes,
+                        'os_version',
+                        100,
+                        GLib.Variant(
+                            '(uuuuuuutut)',
+                            (
+                                700,
+                                10,
+                                500,
+                                0,
+                                1000000,
+                                0,
+                                200,
+                                10000000000,
+                                50,
+                                20000000000,
+                            )
+                        )
+                    ),
                 ],
                 [],                       # aggregate events
             )
@@ -503,6 +525,19 @@ class TestMetrics(IntegrationTest):
 
             assert dbsession.query(InvalidSingularEvent).count() == 0
             assert dbsession.query(UnknownSingularEvent).count() == 0
+
+            split_flatpak_repo_stats = dbsession.query(SplitFlatpakRepoStats).one()
+            assert split_flatpak_repo_stats.os_version == 'os_version'
+            assert split_flatpak_repo_stats.elapsed == timedelta(seconds=700)
+            assert split_flatpak_repo_stats.num_os_refs == 10
+            assert split_flatpak_repo_stats.num_flatpak_refs == 500
+            assert split_flatpak_repo_stats.num_other_refs == 0
+            assert split_flatpak_repo_stats.num_objects == 1000000
+            assert split_flatpak_repo_stats.num_deltas == 0
+            assert split_flatpak_repo_stats.num_apps == 200
+            assert split_flatpak_repo_stats.size_apps == 10000000000
+            assert split_flatpak_repo_stats.num_runtimes == 50
+            assert split_flatpak_repo_stats.size_runtimes == 20000000000
 
     def test_aggregate_events(self):
         from azafea.event_processors.endless.metrics.v3.model import (
@@ -644,7 +679,8 @@ class TestMetrics(IntegrationTest):
             ParentalControlsBlockedFlatpakInstall, ParentalControlsBlockedFlatpakRun,
             ProgramDumpedCore, UpdaterFailure, ParentalControlsEnabled,
             ParentalControlsChanged, WindowsAppOpened, DailyAppUsage, MonthlyAppUsage,
-            DailyUsers, MonthlyUsers, DailySessionTime, MonthlySessionTime
+            DailyUsers, MonthlyUsers, DailySessionTime, MonthlySessionTime,
+            SplitFlatpakRepoStats,
         )
         self.run_subcommand('initdb')
         self.ensure_tables(
@@ -655,7 +691,8 @@ class TestMetrics(IntegrationTest):
             ParentalControlsBlockedFlatpakInstall, ParentalControlsBlockedFlatpakRun,
             ProgramDumpedCore, UpdaterFailure, ParentalControlsEnabled,
             ParentalControlsChanged, WindowsAppOpened, DailyAppUsage, MonthlyAppUsage,
-            DailyUsers, MonthlyUsers, DailySessionTime, MonthlySessionTime
+            DailyUsers, MonthlyUsers, DailySessionTime, MonthlySessionTime,
+            SplitFlatpakRepoStats,
         )
         now = datetime.now(tz=timezone.utc)
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
@@ -731,6 +768,7 @@ class TestMetrics(IntegrationTest):
             assert dbsession.query(MonthlyUsers).count() == 0
             assert dbsession.query(DailySessionTime).count() == 0
             assert dbsession.query(MonthlySessionTime).count() == 0
+            assert dbsession.query(SplitFlatpakRepoStats).count() == 0
 
     def test_unknown_singular_events(self):
         from azafea.event_processors.endless.metrics.v3.model import (

--- a/azafea/event_processors/endless/metrics/tests_v3/test_events.py
+++ b/azafea/event_processors/endless/metrics/tests_v3/test_events.py
@@ -7,7 +7,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-from datetime import date
+from datetime import date, timedelta
 from typing import Any, Dict
 
 from gi.repository import GLib
@@ -357,6 +357,25 @@ def test_new_unknown_event():
                 {'model': 'model_1', 'cores': 8, 'max_frequency': 14.5},
                 {'model': 'model_2', 'cores': 8, 'max_frequency': 14.5}
             ],
+        },
+    ),
+    (
+        'SplitFlatpakRepoStats',
+        GLib.Variant(
+            '(uuuuuuutut)',
+            (700, 10, 500, 0, 1000000, 0, 200, 10000000000, 50, 20000000000)
+        ),
+        {
+            'elapsed': timedelta(seconds=700),
+            'num_os_refs': 10,
+            'num_flatpak_refs': 500,
+            'num_other_refs': 0,
+            'num_objects': 1000000,
+            'num_deltas': 0,
+            'num_apps': 200,
+            'size_apps': 10000000000,
+            'num_runtimes': 50,
+            'size_runtimes': 20000000000,
         },
     ),
 ])

--- a/azafea/event_processors/endless/metrics/tests_v3/test_utils.py
+++ b/azafea/event_processors/endless/metrics/tests_v3/test_utils.py
@@ -9,6 +9,7 @@
 
 from datetime import datetime, timezone
 from gi.repository import GLib
+import logging
 
 import pytest
 
@@ -47,3 +48,30 @@ def test_get_event_datetime():
 
     assert get_event_datetime(1536122990000000000, 20000000000, 30000000000) \
         == datetime(2018, 9, 5, 4, 50, tzinfo=timezone.utc)
+
+
+def test_clamp_to_int64(caplog):
+    from azafea.event_processors.endless.metrics.v3.utils import clamp_to_int64, log as utils_log
+
+    val = clamp_to_int64(GLib.MAXUINT64)
+    assert val == GLib.MAXINT64
+    assert caplog.records != []
+
+    # Check that the message and exception come through.
+    record = caplog.records[0]
+    assert record.name == utils_log.name
+    assert record.levelno == logging.ERROR
+    assert record.msg == f'Clamped integer larger than MAXINT64: {GLib.MAXUINT64}'
+    assert record.exc_info is not None
+    assert record.exc_info[0] == ValueError
+    assert str(record.exc_info[1]) == f'{GLib.MAXUINT64} larger than {GLib.MAXINT64}'
+
+    caplog.clear()
+    val = clamp_to_int64(GLib.MAXINT64)
+    assert val == GLib.MAXINT64
+    assert caplog.records == []
+
+    caplog.clear()
+    val = clamp_to_int64(GLib.MAXINT64 + 1)
+    assert val == GLib.MAXINT64
+    assert caplog.records != []

--- a/azafea/event_processors/endless/metrics/v2/utils.py
+++ b/azafea/event_processors/endless/metrics/v2/utils.py
@@ -108,8 +108,11 @@ def get_event_datetime(request_absolute_timestamp: int, request_relative_timesta
 
 
 def clamp_to_int64(u64: int) -> int:
-    if u64 > GLib.MAXINT64:
-        log.error(f'Clamped integer larger than MAXINT64: {u64}')
+    try:
+        if u64 > GLib.MAXINT64:
+            raise ValueError(f'{u64} larger than {GLib.MAXINT64}')
+    except ValueError:
+        log.exception(f'Clamped integer larger than MAXINT64: {u64}')
         return GLib.MAXINT64
     else:
         return u64

--- a/azafea/event_processors/endless/metrics/v3/utils.py
+++ b/azafea/event_processors/endless/metrics/v3/utils.py
@@ -50,8 +50,11 @@ def get_event_datetime(request_absolute_timestamp: int, request_relative_timesta
 
 
 def clamp_to_int64(u64: int) -> int:
-    if u64 > GLib.MAXINT64:
-        log.error(f'Clamped integer larger than MAXINT64: {u64}')
+    try:
+        if u64 > GLib.MAXINT64:
+            raise ValueError(f'{u64} larger than {GLib.MAXINT64}')
+    except ValueError:
+        log.exception(f'Clamped integer larger than MAXINT64: {u64}')
         return GLib.MAXINT64
     else:
         return u64


### PR DESCRIPTION
This metric is sent by the `eos-split-flatpak-repo` script to record
statistics about splitting the system Flatpak repo from the system
OSTree repo.

The corresponding client side is in endlessm/eos-boot-helper#361.

https://phabricator.endlessm.com/T32790