### PR TITLE
tests: Stop using future-deprecated datetime.utcnow()

### DIFF
--- a/azafea/event_processors/endless/activation/tests/integration/test_activation_cli.py
+++ b/azafea/event_processors/endless/activation/tests/integration/test_activation_cli.py
@@ -42,7 +42,7 @@ class TestActivation(IntegrationTest):
         self.ensure_tables(Activation)
 
         # Insert an activation with a known bad vendor
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         bad_vendor = 'EnDlEsS'
 
         with self.db as dbsession:
@@ -70,7 +70,7 @@ class TestActivation(IntegrationTest):
         self.ensure_tables(Activation)
 
         # Insert an activation with a known normalized vendor
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         vendor = 'Endless'
         assert vendor == normalize_vendor(vendor)
 
@@ -99,7 +99,7 @@ class TestActivation(IntegrationTest):
 
         # Insert an activation without parsed image components
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             dbsession.add(Activation(image=image_id, product='product', release='release',
@@ -138,7 +138,7 @@ class TestActivation(IntegrationTest):
 
         # Insert an activation without parsed image components
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             dbsession.add(Activation(image=image_id, image_product='eos', image_branch='eos3.7',
@@ -185,7 +185,7 @@ class TestActivation(IntegrationTest):
 
         # Insert an activation with an unknown image
         image_id = 'unknown'
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             dbsession.add(Activation(image=image_id, product='product', release='release',

--- a/azafea/event_processors/endless/activation/tests/integration/test_activation_v1.py
+++ b/azafea/event_processors/endless/activation/tests/integration/test_activation_v1.py
@@ -24,7 +24,7 @@ class TestActivation(IntegrationTest):
         self.ensure_tables(Activation)
 
         # Send an event to the Redis queue
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         self.redis.lpush('test_activation_v1', json.dumps({
             'image': 'eos-eos3.7-amd64-amd64.190419-225606.base',
             'vendor': 'the vendor',
@@ -62,7 +62,7 @@ class TestActivation(IntegrationTest):
         self.ensure_tables(Activation)
 
         # Send an event to the Redis queue
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         self.redis.lpush('test_activation_v1_unknown_image', json.dumps({
             'image': 'unknown',
             'vendor': 'the vendor',
@@ -99,7 +99,7 @@ class TestActivation(IntegrationTest):
         self.ensure_tables(Activation)
 
         # Send an event to the Redis queue
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         self.redis.lpush('test_activation_v1_invalid_image', json.dumps({
             'image': 'image',
             'vendor': 'the vendor',

--- a/azafea/event_processors/endless/activation/tests/test_activation_parsing.py
+++ b/azafea/event_processors/endless/activation/tests/test_activation_parsing.py
@@ -14,7 +14,7 @@ import json
 def test_from_bytes():
     from azafea.event_processors.endless.activation.v1.handler import Activation
 
-    created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+    created_at = datetime.now(tz=timezone.utc)
     activation = Activation.from_serialized(json.dumps({
         'image': 'eos-eos3.7-amd64-amd64.190419-225606.base',
         'vendor': 'the vendor',

--- a/azafea/event_processors/endless/metrics/tests_v2/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests_v2/integration/test_metrics_cli.py
@@ -43,7 +43,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('initdb')
         self.ensure_tables(Request, DualBootBooted)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             dbsession.add(Request(sha512='sha512-1', received_at=occured_at,
@@ -108,7 +108,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('initdb')
         self.ensure_tables(Request, ImageVersion)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
 
         with self.db as dbsession:
@@ -174,7 +174,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('initdb')
         self.ensure_tables(Request, LiveUsbBooted)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             dbsession.add(Request(sha512='sha512-1', received_at=occured_at,
@@ -241,7 +241,7 @@ class TestMetrics(IntegrationTest):
         self.ensure_tables(Request, UpdaterBranchSelected)
 
         # Insert an event with a known bad vendor
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         bad_vendor = 'EnDlEsS'
         payload = GLib.Variant('mv', GLib.Variant('(sssb)', (
             'whatever, this gets replaced',
@@ -285,7 +285,7 @@ class TestMetrics(IntegrationTest):
         self.ensure_tables(Request, UpdaterBranchSelected)
 
         # Insert an event with a known normalized vendor
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         vendor = 'Endless'
         assert vendor == normalize_vendor(vendor)
         payload = GLib.Variant('mv', GLib.Variant('(sssb)', (
@@ -321,7 +321,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('initdb')
         self.ensure_tables(DualBootBooted, Machine, Request)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             request = Request(sha512='whatever', received_at=occured_at,
@@ -395,7 +395,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('initdb')
         self.ensure_tables(ImageVersion, Machine, Request)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             request = Request(sha512='whatever', received_at=occured_at,
@@ -468,7 +468,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('initdb')
         self.ensure_tables(LiveUsbBooted, Machine, Request)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             request = Request(sha512='whatever', received_at=occured_at,
@@ -545,7 +545,7 @@ class TestMetrics(IntegrationTest):
         self.ensure_tables(Request, ShellAppIsOpen, Uptime, InvalidSequence, InvalidSingularEvent,
                            UnknownSequence, UnknownSingularEvent)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             request = Request(sha512='whatever', received_at=occured_at,
@@ -715,7 +715,7 @@ class TestMetrics(IntegrationTest):
         self.ensure_tables(Request, ShellAppIsOpen, Uptime, InvalidSequence, InvalidSingularEvent,
                            UnknownAggregateEvent, UnknownSequence, UnknownSingularEvent)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             request = Request(sha512='whatever', received_at=occured_at,
@@ -1004,7 +1004,7 @@ class TestMetrics(IntegrationTest):
         self.ensure_tables(OSVersion)
 
         payload = GLib.Variant('mv', GLib.Variant('(sss)', ['"Endless"', '"1.2.3"', 'useless']))
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         with self.db as dbsession:
             version = OSVersion(
                 version='"1.2.3"', user_id=1, payload=payload, occured_at=occured_at)
@@ -1030,7 +1030,7 @@ class TestMetrics(IntegrationTest):
         self.ensure_tables(OSVersion)
 
         payload = GLib.Variant('mv', GLib.Variant('(sss)', ['Endless', '1.2.3', 'useless']))
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         with self.db as dbsession:
             dbsession.add(OSVersion(
                 version='1.2.3', user_id=1, occured_at=occured_at, payload=payload))
@@ -1060,7 +1060,7 @@ class TestMetrics(IntegrationTest):
             'facility': '22KPJ9043L',
         }
         payload = GLib.Variant('mv', GLib.Variant('a{ss}', info))
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         with self.db as dbsession:
             request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='whatever',
@@ -1097,7 +1097,7 @@ class TestMetrics(IntegrationTest):
         empty_info = {
             'id': '', 'city': '', 'state': '', 'street': '', 'country': '', 'facility': ''}
         payload = GLib.Variant('mv', GLib.Variant('a{ss}', info))
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         with self.db as dbsession:
             request = Request(sha512='whatever', received_at=occured_at,
                               absolute_timestamp=1, relative_timestamp=2, machine_id='whatever',
@@ -1124,7 +1124,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('initdb')
         self.ensure_tables(Request)
 
-        occured_at_1 = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at_1 = datetime.now(tz=timezone.utc)
         occured_at_2 = occured_at_1 + timedelta(days=1)
 
         with self.db as dbsession:

--- a/azafea/event_processors/endless/metrics/tests_v2/integration/test_metrics_db_functions.py
+++ b/azafea/event_processors/endless/metrics/tests_v2/integration/test_metrics_db_functions.py
@@ -40,7 +40,7 @@ class TestMetrics(IntegrationTest):
         self.ensure_tables(ImageVersion, Machine, Request)
 
         image_id = 'eosoem-eos3.7-amd64-amd64.190419-225606.base'
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         # Add a request with an image version
         with self.db as dbsession:
@@ -64,7 +64,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('migratedb')
         self.ensure_tables(ImageVersion, Machine, Request)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         # Add a request without an image version
         with self.db as dbsession:

--- a/azafea/event_processors/endless/metrics/tests_v2/integration/test_metrics_v2.py
+++ b/azafea/event_processors/endless/metrics/tests_v2/integration/test_metrics_v2.py
@@ -1962,7 +1962,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('initdb')
         self.ensure_tables(Request, DualBootBooted, ImageVersion, LiveUsbBooted)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             # Add a first request with 1 dualboot, 2 image version and 3 live usb events

--- a/azafea/event_processors/endless/metrics/tests_v3/integration/test_metrics_cli.py
+++ b/azafea/event_processors/endless/metrics/tests_v3/integration/test_metrics_cli.py
@@ -27,7 +27,7 @@ class TestMetrics(IntegrationTest):
         self.ensure_tables(
             Channel, InvalidSingularEvent, UnknownSingularEvent)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
 
         with self.db as dbsession:
@@ -140,7 +140,7 @@ class TestMetrics(IntegrationTest):
             Channel, InvalidSingularEvent, UnknownSingularEvent, ParentalControlsEnabled,
         )
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
 
         with self.db as dbsession:
@@ -219,7 +219,7 @@ class TestMetrics(IntegrationTest):
         self.run_subcommand('initdb')
         self.ensure_tables(Channel, UnknownAggregateEvent)
 
-        occured_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        occured_at = datetime.now(tz=timezone.utc)
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
 
         with self.db as dbsession:

--- a/azafea/event_processors/endless/ping/tests/integration/test_ping_cli.py
+++ b/azafea/event_processors/endless/ping/tests/integration/test_ping_cli.py
@@ -42,7 +42,7 @@ class TestPing(IntegrationTest):
         self.ensure_tables(PingConfiguration)
 
         # Insert a ping configuration with a known bad vendor
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         bad_vendor = 'EnDlEsS'
 
         with self.db as dbsession:
@@ -70,7 +70,7 @@ class TestPing(IntegrationTest):
         self.ensure_tables(PingConfiguration)
 
         # Insert a ping configuration with a known normalized vendor
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         vendor = 'Endless'
         assert vendor == normalize_vendor(vendor)
 
@@ -98,7 +98,7 @@ class TestPing(IntegrationTest):
         self.ensure_tables(PingConfiguration)
 
         # Insert a ping configuration with a known bad vendor, with a first ping
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             ping_config = PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
@@ -110,7 +110,7 @@ class TestPing(IntegrationTest):
 
         # Insert another ping configuration with a known bad vendor which normalizes to the same
         # vendor as the previous one
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             ping_config = PingConfiguration(image='eos-eos3.7-amd64-amd64.190419-225606.base',
@@ -162,7 +162,7 @@ class TestPing(IntegrationTest):
         self.ensure_tables(PingConfiguration)
 
         # Insert a ping configuration with a known bad vendor, with a first ping
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         bad_vendor = 'EnDlEsS'
 
         with self.db as dbsession:
@@ -174,7 +174,7 @@ class TestPing(IntegrationTest):
                                created_at=created_at))
 
         # Now insert a ping configuration with a known normalized vendor, with a second ping
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         good_vendor = normalize_vendor(bad_vendor)
 
         with self.db as dbsession:
@@ -230,7 +230,7 @@ class TestPing(IntegrationTest):
 
         # Insert a ping configuration without parsed image components
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             dbsession.add(PingConfiguration(image=image_id, product='product', release='release',
@@ -268,7 +268,7 @@ class TestPing(IntegrationTest):
 
         # Insert a ping configuration without parsed image components
         image_id = 'eos-eos3.7-amd64-amd64.190419-225606.base'
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             dbsession.add(PingConfiguration(image=image_id, image_product='eos',
@@ -315,7 +315,7 @@ class TestPing(IntegrationTest):
 
         # Insert a ping configuration without parsed image components
         image_id = 'unknown'
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
 
         with self.db as dbsession:
             dbsession.add(PingConfiguration(image=image_id, product='product', release='release',

--- a/azafea/event_processors/endless/ping/tests/integration/test_ping_v1.py
+++ b/azafea/event_processors/endless/ping/tests/integration/test_ping_v1.py
@@ -24,7 +24,7 @@ class TestPing(IntegrationTest):
         self.ensure_tables(Ping, PingConfiguration)
 
         # Send an event to the Redis queue
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         self.redis.lpush('test_ping_v1', json.dumps({
             'image': 'eos-eos3.7-amd64-amd64.190419-225606.base',
             'vendor': 'the vendor',
@@ -66,7 +66,7 @@ class TestPing(IntegrationTest):
         self.ensure_tables(Ping, PingConfiguration)
 
         # Send events to the Redis queue
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         for i in range(10):
             self.redis.lpush('test_ping_configuration_v1_dualboot_unicity', json.dumps({
                 'image': 'eos-eos3.7-amd64-amd64.190419-225606.base',
@@ -106,7 +106,7 @@ class TestPing(IntegrationTest):
         self.ensure_tables(Ping, PingConfiguration)
 
         # Send an event to the Redis queue
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         self.redis.lpush('test_ping_v1_unknown_image', json.dumps({
             'image': 'unknown',
             'vendor': 'the vendor',
@@ -148,7 +148,7 @@ class TestPing(IntegrationTest):
         self.ensure_tables(Ping, PingConfiguration)
 
         # Send an event to the Redis queue
-        created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+        created_at = datetime.now(tz=timezone.utc)
         self.redis.lpush('test_ping_v1_invalid_image', json.dumps({
             'image': 'image',
             'vendor': 'the vendor',

--- a/azafea/event_processors/endless/ping/tests/test_ping_parsing.py
+++ b/azafea/event_processors/endless/ping/tests/test_ping_parsing.py
@@ -14,7 +14,7 @@ import json
 def test_from_bytes():
     from azafea.event_processors.endless.ping.v1.handler import Ping
 
-    created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+    created_at = datetime.now(tz=timezone.utc)
     ping = Ping.from_serialized(json.dumps({
         'release': 'release',
         'count': 43,
@@ -31,7 +31,7 @@ def test_from_bytes():
 def test_from_bytes_missing_count():
     from azafea.event_processors.endless.ping.v1.handler import Ping
 
-    created_at = datetime.utcnow().replace(tzinfo=timezone.utc)
+    created_at = datetime.now(tz=timezone.utc)
     ping = Ping.from_serialized(json.dumps({
         'release': 'release',
         'created_at': created_at.strftime('%Y-%m-%d %H:%M:%S.%fZ'),


### PR DESCRIPTION
https://blog.ganssle.io/articles/2019/11/utcnow.html lays out why this function is bad. In fact I believe the usage in the tests is safe. However Python 3.12 will formally deprecate this function: https://discuss.python.org/t/deprecating-utcnow-and-utcfromtimestamp/26221

Replace it with the recommended (and shorter!) alternative.