### PR TITLE
Drop tour response event

### DIFF
--- a/azafea/event_processors/endless/metrics/v3/model/_base.py
+++ b/azafea/event_processors/endless/metrics/v3/model/_base.py
@@ -38,6 +38,7 @@ AGGREGATE_EVENT_MODELS: Dict[str, Type['AggregateEvent']] = {}
 
 IGNORED_EVENTS: Set[str] = {
     '005096c4-9444-48c6-844b-6cb693c15235',
+    '140643be-fe47-4b4b-985b-d16f8f3973a9',
     '337fa66d-5163-46ae-ab20-dc605b5d7307',
     '350ac4ff-3026-4c25-9e7e-e8103b4fd5d8',
     '3a4eff55-5d01-48c8-a827-fca5732fd767',

--- a/azafea/event_processors/endless/metrics/v3/model/_base.py
+++ b/azafea/event_processors/endless/metrics/v3/model/_base.py
@@ -39,8 +39,8 @@ AGGREGATE_EVENT_MODELS: Dict[str, Type['AggregateEvent']] = {}
 IGNORED_EVENTS: Set[str] = {
     '005096c4-9444-48c6-844b-6cb693c15235',
     '337fa66d-5163-46ae-ab20-dc605b5d7307',
-    '3a4eff55-5d01-48c8-a827-fca5732fd767',
     '350ac4ff-3026-4c25-9e7e-e8103b4fd5d8',
+    '3a4eff55-5d01-48c8-a827-fca5732fd767',
     '566adb36-7701-4067-a971-a398312c2874',
     '5fae6179-e108-4962-83be-c909259c0584',
     '6dad6c44-f52f-4bca-8b4c-dc203f175b97',

--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -946,6 +946,34 @@ Automatic updates settings have changed.
 
 .. versionadded:: 3.9.1
 
+Tour Response
+~~~~~~~~~~~~~
+
+When a user first logs into GNOME 40+ (which in the case of Endless OS means
+Endless OS 5), they are offered the chance to take a tour. This event had a
+boolean payload, ``true`` if the user chose to take the tour and ``false``
+otherwise.
+
+Combined with the image ID from the channel, this data can be separated into
+new installations, and users upgrading from Endless OS 4 and older.
+
+Over a period of just under a year, we determined:
+
+- 15% of users upgrading from Endless OS 4 took the tour
+- 32% of users starting from Endless OS 5 took the tour
+- 19% of users overall took the tour
+
+Having validated our belief that relatively few users would opt to choose the
+tour, and learned that upgrading users are less likely to take it (which is a
+shame since they are the ones whose desktop changed significantly when they
+upgrade to Endless OS 5), we removed this event in Endless OS 5.2.0 and
+discarded the data on the server.
+
+:UUID: ``140643be-fe47-4b4b-985b-d16f8f3973a9``
+:UUID name: ``TOUR_RESPONSE_EVENT`` in gnome-shell
+
+.. versionadded:: 5.0.0
+
 
 Test Events
 -----------


### PR DESCRIPTION
As described in the main commit, we have learned what we wanted to learn by collecting this event. We can now remove the data from the database and stop storing new submissions.

https://phabricator.endlessm.com/T35061
