### PR TITLE
Adjust RTD requirements scripts for pipenv >= 2022.8.13

### DIFF
--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -22,5 +22,5 @@ sqlalchemy==1.3.24
 toml==0.10.2
 typing-extensions==3.10.0.0
 urllib3==1.26.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
-sphinx-rtd-theme==1.0.0
 sphinx==4.1.1
+sphinx-rtd-theme==1.0.0

--- a/update-rtd-requirements
+++ b/update-rtd-requirements
@@ -53,11 +53,11 @@ trap 'rm -f "$tmpreqs"' EXIT
 EOF
 
     # Standard package requirements so that sphinx-build can succeed.
-    pipenv lock --requirements --keep-outdated --no-header
+    pipenv requirements
 
     # Dev packages required for RTD.
-    # https://docs.readthedocs.io/en/stable/builds.html#default-versions-of-dependencies
-    pipenv lock --dev-only --requirements --keep-outdated | grep \
+    # https://docs.readthedocs.io/en/stable/build-default-versions.html
+    pipenv requirements --dev-only | grep \
         -e '^sphinx\b' \
         -e '^sphinx-rtd-theme\b'
 ) > "$tmpreqs"


### PR DESCRIPTION
Since pipenv 2022.8.13, `pipenv lock --requirements` has been removed in favor of the `pipenv requirements` command[1]. Adjust the RTD requirements script accordingly and regenerate the requirements file with the minor sorting change from current pipenv.

1. https://github.com/pypa/pipenv/blob/main/CHANGELOG.md#2022813-2022-08-13