### PR TITLE
Ingest CPU flags from ComputerInformation event

### DIFF
--- a/azafea/event_processors/endless/metrics/tests_v3/test_events.py
+++ b/azafea/event_processors/endless/metrics/tests_v3/test_events.py
@@ -360,6 +360,29 @@ def test_new_unknown_event():
         },
     ),
     (
+        'ComputerInformation',
+        GLib.Variant(
+            '(uuuua(sqds))',
+            (
+                40000,
+                50000000,
+                300000,
+                49700000,
+                [('model_1', 8, 14.5, 'a a b'), ('model_2', 8, 14.5, ' d  b  c ')]
+            )
+        ),
+        {
+            'total_ram': 40000,
+            'total_disk': 50000000,
+            'used_disk': 300000,
+            'free_disk': 49700000,
+            'info': [
+                {'model': 'model_1', 'cores': 8, 'max_frequency': 14.5, 'flags': ['a', 'b']},
+                {'model': 'model_2', 'cores': 8, 'max_frequency': 14.5, 'flags': ['b', 'c', 'd']},
+            ],
+        },
+    ),
+    (
         'SplitFlatpakRepoStats',
         GLib.Variant(
             '(uuuuuuutut)',


### PR DESCRIPTION
We would like to adjust the CPU information sent by eos-metrics-instrumentation to include CPU flags: statistics about how widely-supported certain extensions are will allow the freedesktop-sdk project to quantify the impact of (for example) assuming certain x86-64 extensions are present.

Previously, events with some given UUID are expected to have a payload of one specific GVariant type, and those types are typically not something extensible like `a{sv}`. This is quite annoying when we want to add a new field, particularly in this CPU data which just ends up being stuffed into a JSONB column in the database.

So, allow event models to specify a tuple of accepted GVariant types; then take advantage of this in the ComputerInformation model to understand a new type with an extra string of CPU flags.

https://phabricator.endlessm.com/T35351

- https://github.com/endlessm/eos-metrics-instrumentation/pull/113