### PR TITLE
Handle configuration in Docker correctly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 /.coverage
 /.dockerignore
+/.env
 /.git
 /.gitignore
 /.mypy_cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.cache
 /.coverage*
+/.env
 /.local
 /.mypy_cache/
 /azafea.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,13 @@ COPY --chown=azafea:root . .
 ENV VERBOSE=false \
     NUM_OF_WORKERS=1 \
     REDIS_HOST=localhost \
+    REDIS_PORT=6379 \
     REDIS_PASSWORD="CHANGE ME!!" \
     POSTGRES_HOST=localhost \
+    POSTGRES_PORT=5432 \
+    POSTGRES_USER=azafea \
     POSTGRES_PASSWORD="CHANGE ME!!" \
+    POSTGRES_DATABASE=azafea \
     POSTGRES_SSL_MODE=allow
 
 ENTRYPOINT ["./entrypoint", "pipenv", "run", "azafea", "-c", "/tmp/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,5 @@ ENV VERBOSE=false \
     POSTGRES_SSL_MODE=allow
 
 ENTRYPOINT ["./entrypoint", "pipenv", "run", "azafea", "-c", "/tmp/config.toml"]
+CMD ["run"]
 HEALTHCHECK CMD pgrep python || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,5 @@ ENV VERBOSE=false \
     POSTGRES_PASSWORD="CHANGE ME!!" \
     POSTGRES_SSL_MODE=allow
 
-ENTRYPOINT ["./entrypoint", "pipenv", "run", "azafea"]
+ENTRYPOINT ["./entrypoint", "pipenv", "run", "azafea", "-c", "/tmp/config.toml"]
 HEALTHCHECK CMD pgrep python || exit 1

--- a/config.toml.j2
+++ b/config.toml.j2
@@ -4,11 +4,15 @@ number_of_workers = {{ NUM_OF_WORKERS }}
 
 [redis]
 host = "{{ REDIS_HOST }}"
+port = {{ REDIS_PORT }}
 password = "{{ REDIS_PASSWORD }}"
 
 [postgresql]
 host = "{{ POSTGRES_HOST }}"
+port = {{ POSTGRES_PORT }}
+user = "{{ POSTGRES_USER }}"
 password = "{{ POSTGRES_PASSWORD }}"
+database = "{{ POSTGRES_DATABASE }}"
 
 [queues.activation-1]
 handler = "azafea.event_processors.endless.activation.v1"

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -80,44 +80,84 @@ locally::
     $ cd azafea
     $ sudo docker build --tag azafea .
 
-At this point you will probably want to
-:doc:`write a local configuration file <configuration>` before running Azafea.
-
-In particular, you will at the very least want to:
+At this point you need to configure Azafea. In particular, you will at
+the very least want to:
 
 * change the Redis and PostgreSQL hosts, to point them to the IP addresses of
   their respective containers;
 * change the Redis and PostgreSQL passwords;
 * add at least one queue configuration.
 
-We recommend saving the configuration file as ``/etc/azafea/config.toml`` on
-the production host.
+The container will automatically generate a :doc:`configuration file
+<configuration>` from environment variables. The supported environment
+variables are:
 
+* ``VERBOSE``: Sets the ``main.verbose`` value. (Default: ``false``)
+* ``NUM_OF_WORKERS``: Sets the ``main.number_of_workers`` value.
+* ``REDIS_HOST``: Sets the ``redis.host`` value. (Default: ``localhost``)
+* ``REDIS_PASSWORD``: Sets the ``redis.password`` value. (Default: ``CHANGE
+  ME!!``)
+* ``POSTGRES_HOST``: Sets the ``postgresql.host`` value. (Default:
+  ``localhost``)
+* ``POSTGRES_PASSWORD``: Sets the ``postgresql.password`` value. (Default:
+  ``CHANGE ME!!``)
+* ``POSTGRES_SSL_MODE``: Sets the ``postgresql.connect_args.sslmode`` value.
+  (Default: ``allow``)
+
+Alternatively, you can :doc:`write a local configuration file <configuration>`
+before running Azafea. This requires running the Docker container differently
+as described below.
 
 Running
 =======
 
 .. note::
-    The commands below all assume that you're using the Docker Hub image and
-    your config file is at ``/etc/azafea/config.toml``. If you're using a built
-    image, adapt the ``docker.io/endlessm/azafea`` argument to use the tag you
-    passed in ``--tag``. If you saved it elsewhere, you will need to adapt the
-    ``--volume`` argument.
+    The commands below all assume that you're using the Docker Hub image with
+    environment variable configuration. If you're using a built image, adapt
+    the ``docker.io/endlessm/azafea`` argument to use the tag you passed in
+    ``--tag``. See the end of this section if you want to use a local
+    configuration file.
 
 Once you built the Docker image and wrote your configuration file, you can
 ensure that Azafea loads your configuration correctly with the following
 command::
 
-    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro docker.io/endlessm/azafea print-config
+    $ sudo docker run --env=REDIS_HOST=localhost \
+                      --env=REDIS_PASSWORD=S3cretRedisP@ssw0rd \
+                      --env=POSTGRES_HOST=localhost \
+                      --env=POSTGRES_PASSWORD=S3cretPgAdminP@ssw0rd \
+                      docker.io/endlessm/azafea \
+                      print-config
 
 If everything is the way you want it, it is time to initialize the database,
 creating all the tables::
 
-    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro docker.io/endlessm/azafea migratedb
+    $ sudo docker run --env=REDIS_HOST=localhost \
+                      --env=REDIS_PASSWORD=S3cretRedisP@ssw0rd \
+                      --env=POSTGRES_HOST=localhost \
+                      --env=POSTGRES_PASSWORD=S3cretPgAdminP@ssw0rd \
+                      docker.io/endlessm/azafea \
+                      migratedb
 
 Finally, you can run Azafea::
 
-    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro docker.io/endlessm/azafea run
+    $ sudo docker run --env=REDIS_HOST=localhost \
+                      --env=REDIS_PASSWORD=S3cretRedisP@ssw0rd \
+                      --env=POSTGRES_HOST=localhost \
+                      --env=POSTGRES_PASSWORD=S3cretPgAdminP@ssw0rd \
+                      docker.io/endlessm/azafea \
+                      run
+
+If you're using a local configuration file, 2 changes are needed. First, rather
+than passing ``--env`` to ``docker run``, the file needs to be mounted into the
+container using the ``--volume`` option. For example,
+``--volume=/path/to/config.toml:/config.toml:ro`` would mount the configuration
+file at ``/path/to/config.toml`` to ``/config.toml`` within the container and
+makes it read-only.
+
+Second, Azafea needs to be told about the location of the configuration within
+the container. This needs to be passed as the first argument in the container
+command using the ``-c`` option. For example, ``-c /config.toml print-config``.
 
 Upgrading the Database
 ======================
@@ -128,4 +168,9 @@ database model.
 To reflect the code changes into PostgreSQL, you should run the following
 command every time you update::
 
-    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro docker.io/endlessm/azafea migratedb
+    $ sudo docker run --env=REDIS_HOST=localhost \
+                      --env=REDIS_PASSWORD=S3cretRedisP@ssw0rd \
+                      --env=POSTGRES_HOST=localhost \
+                      --env=POSTGRES_PASSWORD=S3cretPgAdminP@ssw0rd \
+                      docker.io/endlessm/azafea \
+                      migratedb

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -95,12 +95,17 @@ variables are:
 * ``VERBOSE``: Sets the ``main.verbose`` value. (Default: ``false``)
 * ``NUM_OF_WORKERS``: Sets the ``main.number_of_workers`` value.
 * ``REDIS_HOST``: Sets the ``redis.host`` value. (Default: ``localhost``)
+* ``REDIS_PORT``: Sets the ``redis.port`` value. (Default: 6379)
 * ``REDIS_PASSWORD``: Sets the ``redis.password`` value. (Default: ``CHANGE
   ME!!``)
 * ``POSTGRES_HOST``: Sets the ``postgresql.host`` value. (Default:
   ``localhost``)
+* ``POSTGRES_PORT``: Sets the ``postgresql.port`` value. (Default: 5432)
+* ``POSTGRES_USER``: Sets the ``postgresql.user`` value. (Default: ``azafea``)
 * ``POSTGRES_PASSWORD``: Sets the ``postgresql.password`` value. (Default:
   ``CHANGE ME!!``)
+* ``POSTGRES_DATABASE``: Sets the ``postgresql.database`` value. (Default:
+  ``azafea``)
 * ``POSTGRES_SSL_MODE``: Sets the ``postgresql.connect_args.sslmode`` value.
   (Default: ``allow``)
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -145,8 +145,7 @@ Finally, you can run Azafea::
                       --env=REDIS_PASSWORD=S3cretRedisP@ssw0rd \
                       --env=POSTGRES_HOST=localhost \
                       --env=POSTGRES_PASSWORD=S3cretPgAdminP@ssw0rd \
-                      docker.io/endlessm/azafea \
-                      run
+                      docker.io/endlessm/azafea
 
 If you're using a local configuration file, 2 changes are needed. First, rather
 than passing ``--env`` to ``docker run``, the file needs to be mounted into the

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -67,9 +67,14 @@ We can now run PostgreSQL, telling it to use that volume::
 Azafea
 ------
 
-The easiest deployment method is also to use Docker.
+The easiest deployment method is also to use Docker. The image is published on
+`Docker Hub`_ and can be downloaded by running ``sudo docker pull
+docker.io/endlessm/azafea``.
 
-You need to first get the sources and build the Docker image::
+.. _Docker Hub: https://hub.docker.com/r/endlessm/azafea
+
+If you prefer, you can first get the sources and build the Docker image
+locally::
 
     $ git clone https://github.com/endlessm/azafea
     $ cd azafea
@@ -93,24 +98,26 @@ Running
 =======
 
 .. note::
-    The commands  below all assume that your config file is at
-    ``/etc/azafea/config.toml``. If you saved it elsewhere, you will need to
-    adapt the ``--volume`` argument.
+    The commands below all assume that you're using the Docker Hub image and
+    your config file is at ``/etc/azafea/config.toml``. If you're using a built
+    image, adapt the ``docker.io/endlessm/azafea`` argument to use the tag you
+    passed in ``--tag``. If you saved it elsewhere, you will need to adapt the
+    ``--volume`` argument.
 
 Once you built the Docker image and wrote your configuration file, you can
 ensure that Azafea loads your configuration correctly with the following
 command::
 
-    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro azafea print-config
+    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro docker.io/endlessm/azafea print-config
 
 If everything is the way you want it, it is time to initialize the database,
 creating all the tables::
 
-    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro azafea migratedb
+    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro docker.io/endlessm/azafea migratedb
 
 Finally, you can run Azafea::
 
-    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro azafea run
+    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro docker.io/endlessm/azafea run
 
 Upgrading the Database
 ======================
@@ -121,4 +128,4 @@ database model.
 To reflect the code changes into PostgreSQL, you should run the following
 command every time you update::
 
-    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro azafea migratedb
+    $ sudo docker run --volume=/etc/azafea:/etc/azafea:ro docker.io/endlessm/azafea migratedb


### PR DESCRIPTION
The real fix is in [docker: Use config generated by entrypoint](https://github.com/endlessm/azafea/commit/cb8c3f091320d9c99310227ed205ad65b5dba009). This instructs azafea to use the templated configuration file so that the environment variables set for the container actually work. The others are some polish and documentation I came across while looking at this.

Fixes: #188