### PR TITLE
endless: Handle image ID "[Invalid UTF-8]" like "unknown"

### DIFF
--- a/azafea/event_processors/endless/image.py
+++ b/azafea/event_processors/endless/image.py
@@ -55,9 +55,12 @@ class ImageParsingError(Exception):
 
 
 def parse_endless_os_image(image_id: str, tzinfo: bool = True) -> ParsedImage:
-    if image_id == 'unknown':
-        # In case of errors, the activation and pings come with an "unknown" image id which we must
-        # treat as valid
+    if image_id in ('unknown', '[Invalid UTF-8]'):
+        # If the image ID cannot be read from disk, the activation/ping and metrics submissions
+        # use the string "unknown", which we must treat as valid-but-empty.
+        #
+        # Due to a bug in eos-event-recorder-daemon in eos4.0 and eos5.0, a missing image ID would
+        # instead lead to the string "[Invalid UTF-8]" being used; treat this the same as "unknown".
         return {
             'image_product': None,
             'image_branch': None,

--- a/azafea/event_processors/endless/tests/test_image.py
+++ b/azafea/event_processors/endless/tests/test_image.py
@@ -58,6 +58,17 @@ import pytest
             'image_personality': None
         }
     ),
+    (
+        '[Invalid UTF-8]',
+        {
+            'image_product': None,
+            'image_branch': None,
+            'image_arch': None,
+            'image_platform': None,
+            'image_timestamp': None,
+            'image_personality': None
+        }
+    ),
 ])
 def test_parse_endless_os_image(image_id, expected):
     from azafea.event_processors.endless.image import parse_endless_os_image


### PR DESCRIPTION
Endless OS 4.0.x and 5.0.x would submit this string if the image version could not be read as valid UTF-8 from disk. (This string comes from within GLib if you pass a NULL pointer as the argument for a 's' type code in a call to g_variant_new().)

This is fixed in Endless OS 5.1.0 and newer, but we have many requests in the error queue which are failing to be loaded for this reason.

Treat "[Invalid UTF-8]" the same as "unknown".

https://phabricator.endlessm.com/T35279

https://github.com/endlessm/eos-event-recorder-daemon/commit/13d533b5d47cc592545cbcb63cb17c28df860762