### PR TITLE
github: Use API key instead of username/password

### DIFF
--- a/.github/workflows/metabase.yml
+++ b/.github/workflows/metabase.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3.11-alpine
     env:
-      METABASE_USERNAME: ${{ secrets.METABASE_USERNAME }}
-      METABASE_PASSWORD: ${{ secrets.METABASE_PASSWORD }}
+      METABASE_API_KEY: ${{ secrets.METABASE_API_KEY }}
       METABASE_DRY_RUN: >-
         ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
     steps:


### PR DESCRIPTION
An API key is the preferred way to authenticate to the Metabase API. The metabase builder supports API keys using the `METABASE_API_KEY` environment variable since 7337d7a.

https://phabricator.endlessm.com/T32367

This depends on https://github.com/endlessm/eos-administration/pull/1448.