### PR TITLE
docker: Update AWS RDS CA bundle URL

### DIFF
--- a/.github/workflows/metabase.yml
+++ b/.github/workflows/metabase.yml
@@ -30,6 +30,6 @@ jobs:
         run: pip install --no-cache-dir pipenv
       - uses: actions/checkout@v4
       - name: Install Dev Dependencies
-        run: pipenv install --dev
+        run: pipenv sync --dev
       - name: Upload Documentation
         run: pipenv run metabase -E

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.hub.docker.com/library/python:3.11-alpine
 
 RUN apk add --update --no-cache ca-certificates && \
-    wget https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -O /usr/local/share/ca-certificates/rds.crt && \
+    wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /usr/local/share/ca-certificates/rds.crt && \
     update-ca-certificates
 
 RUN pip install --no-cache-dir pipenv template && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ USER azafea
 WORKDIR /opt/azafea/src
 
 COPY Pipfile.lock .
-RUN pipenv install --ignore-pipfile --dev
+RUN pipenv sync --dev --clear
 
 COPY --chown=azafea:root . .
 


### PR DESCRIPTION
We've been installing the RDS CA bundle from
https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem for years. However, the documented[1] URL is
https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem. The former hasn't been updated in years and all the certificates in it are about to expire:

$ curl -sSIL https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem | grep -i ^last-modified: Last-Modified: Tue, 28 Apr 2020 15:18:37 GMT
$ curl -sSIL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem | grep -i ^last-modified: last-modified: Mon, 18 Dec 2023 20:34:46 GMT

This should have no compatibility issues as global-bundle.pem is a superset of rds-combined-ca-bundle.pem including all the soon to be expired CA certificates.

1. https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions

https://phabricator.endlessm.com/T35141